### PR TITLE
#360 #362 black outs controller refactoring

### DIFF
--- a/app/controllers/black_outs_controller.rb
+++ b/app/controllers/black_outs_controller.rb
@@ -1,9 +1,9 @@
 class BlackOutsController < ApplicationController
 
   before_filter :require_admin
-  before_filter :set_params_for_create_and_update, :only => [:create, :update]
-  before_filter :set_current_blackout, :except => [:index, :new, :create, :new_recurring]
-  before_filter :validate_recurring_date_params, :only => [:create]
+  before_filter :set_params_for_create_and_update, :only => [:create, :create_recurring, :update]
+  before_filter :set_current_blackout, :only => [:edit, :show, :update, :destroy, :destroy_recurring]
+  before_filter :validate_recurring_date_params, :only => [:create_recurring]
 
   
   # ---------- before filter methods ------------ #
@@ -29,6 +29,7 @@ class BlackOutsController < ApplicationController
 
   #validates that date selection was done correctly when the form calls the create method
   def validate_recurring_date_params
+
     if params[:recurring] == "true"
       # make sure there are actually days selected
       if params[:black_out][:days].first.blank?
@@ -89,8 +90,8 @@ class BlackOutsController < ApplicationController
   def edit
   end
 
-  #called by create when a recurring blackout is needed
-  def create_recurring_blackout_helper
+  #called when a recurring blackout is needed
+  def create_recurring
 
     #generate a unique id for this blackout date set
     if BlackOut.last.nil?
@@ -123,25 +124,19 @@ class BlackOutsController < ApplicationController
 
   def create
     # create a non-recurring blackout
-    if params[:recurring] != "true"
-      params[:black_out][:set_id] = NIL # the blackouts not belonging to a set
-      @black_out = BlackOut.new(params[:black_out])
+    params[:black_out][:set_id] = NIL # the blackouts not belonging to a set
+    @black_out = BlackOut.new(params[:black_out])
 
-      # save and exit
-      respond_to do |format|
-        if @black_out.save
-          format.html { redirect_to @black_out, notice: 'Blackout was successfully created.' }
-          format.js {render :action => 'create_success' and return}
-        else
-          format.html { render action: "new" }
-          format.js { render :action => 'load_custom_errors', notice: 'Unable to save blackout date.' and return}
-        end
+    # save and exit
+    respond_to do |format|
+      if @black_out.save
+        format.html { redirect_to @black_out, notice: 'Blackout was successfully created.' }
+        format.js {render :action => 'create_success' and return}
+      else
+        format.html { render action: "new" }
+        format.js { render :action => 'load_custom_errors', notice: 'Unable to save blackout date.' and return}
       end
-    else
-      # otherwise, call this method to create a recurring blackout
-      create_recurring_blackout_helper
     end
-
   end
 
   def update

--- a/app/views/black_outs/_form_recurring.html.erb
+++ b/app/views/black_outs/_form_recurring.html.erb
@@ -1,5 +1,5 @@
 <div id="form_recurring">
-  <%= simple_form_for @black_out, :remote => true do |f| %>
+  <%= simple_form_for(@black_out, :url => create_recurring_black_outs_path, :method => 'post', :remote => true ) do |f| %>
     <%= f.error_notification %>
 
     <div class="form-inputs">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Reservations::Application.routes.draw do
   match '/black_outs/new_recurring' => 'black_outs#new_recurring', :as => :new_recurring_black_out
 
   resources :black_outs do
+    collection do
+      post :create_recurring
+    end
     member do
       get :flash_message
       delete :destroy_recurring


### PR DESCRIPTION
Refactored throughout BlackOutsController

Note: There is still a bug when trying to create a recurring blackout with a date (or dates) selected but the rest of the form filled out incorrectly. Rather than producing an error message, there is a redirect_to :back without saving a blackout to the database.

This error existed before these changes and should be addressed in another issue.
