### PR TITLE
IdeaScale Reservation History For Kits

### DIFF
--- a/app/assets/stylesheets/equipment_models/_show.css.scss
+++ b/app/assets/stylesheets/equipment_models/_show.css.scss
@@ -44,6 +44,11 @@
 	line-height: $baseLineHeight;
 }
 
+.label.label-warning.eo-table {
+	font-size: $baseFontSize;
+	line-height: $baseLineHeight;
+}
+
 .subnav li h4 {
 	padding-top: 11px;
 	padding-bottom: 11px;

--- a/app/views/equipment_models/_equipment_objects_table.html.erb
+++ b/app/views/equipment_models/_equipment_objects_table.html.erb
@@ -18,6 +18,8 @@
       <td><%= equipment_object.serial %></td>
       <% if equipment_object.status == "available" %>
         <td><span class="label label-success eo-table">Available</span></td>
+      <% elsif equipment_object.status == "Deactivated" %>
+        <td><span class="label label-warning eo-table">Deactivated</span></td>
       <% else %>
         <% current_res = equipment_object.current_reservation %>
         <td><%= link_to_if current_res, equipment_object.status, current_res %></td>

--- a/app/views/equipment_objects/show.html.erb
+++ b/app/views/equipment_objects/show.html.erb
@@ -16,10 +16,37 @@
 </p>
 <p>
   <strong>Status:</strong>
-  <%= @equipment_object.status %>
+  <% if @equipment_object.status == 'Deactivated' %>
+    <span class="label label-warning eo-table">Deactivated</span>
+  <% elsif @equipment_object.status == 'available' %>
+    <span class="label label-success eo-table">Available</span>
+  <% else %>
+    <%= link_to "#{@equipment_object.status}", @equipment_object.current_reservation %>
+  <%end%>
 </p>
+
+<section>
+  <h2>Associated Reservations</h2><hr />
+  <div class="row">
+    <div class="span9">
+      <%= render :partial => "reservations/reservations_list", locals: { :reservations_list => Reservation.where("equipment_object_id = ?", @equipment_object) } %>
+    </div>
+  </div>
+</section>
+
+<section id="row">
+  <h2>Deactivation Records</h2><hr />
+    <div class="row">
+      <div class="span9">
+        <p>
+          This data is not currently tracked by the database, we will hopefully be adding this feature soon!
+        </p>
+      </div>
+    </div>
+</section>
+
 <div class="form-actions">
   <%= link_to "Edit", edit_equipment_object_path(@equipment_object), class: 'btn' %>
   <%= link_to "Delete", @equipment_object, :confirm => 'Deleting this Equipment Item will delete all related reservations. Are you sure you want to do this?', :method => :delete, class: 'btn btn-danger' %>
-  <%= link_to "View All", equipment_objects_path, class: 'btn' %>
+  <%= link_to "View All #{@equipment_object.equipment_model.name}'s", equipment_model_path(@equipment_object.equipment_model_id, anchor: 'items'), class: 'btn' %>
 </div>


### PR DESCRIPTION
This adds a reservation history table to the equipment_item show page. Some other small improvements to the UI for equipment items throughout the application.
