### PR TITLE
Reservation validator is checking wrong date

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -87,7 +87,7 @@ class Reservation < ActiveRecord::Base
   # the array of reservations passed in (use with cart.cart_reservations)
   # Returns an array of error messages or [] if reservations are all valid
   def self.validate_set(user, res_array = [])
-    all_res_array = res_array + user.reservations
+    all_res_array = res_array + user.reservations.checked_out
     errors = []
     all_res_array.each do |res|
       errors << user.name + " has overdue reservations that prevent new ones from being created" unless res.no_overdue_reservations?


### PR DESCRIPTION
From #484:

> I think this same thing is happening to [someone on Forestry](http://ulua.its.yale.edu/forestry/users/216) - I see one thing as "past overdue"
> 
> ![68747470733a2f2f636c6f75642e67697468756275736572636f6e74656e742e636f6d2f6173736574732f3237333635332f323533323931372f65376130643466362d623534642d313165332d383965652d3139373236313436353664322e706e67](https://cloud.githubusercontent.com/assets/901808/2532993/d5b7f4ac-b54f-11e3-818f-01e04d1cd80a.png)

It appears as though the reservation date validators are pulling the wrong date (03/01/2014 instead of the the requested 03/31/2014), not sure why.  It seems specific to this user's account, I will investigate.
