### PR TITLE
Adding unavailable items to cart causes infinite js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -321,7 +321,7 @@ $(document).on('change', '.autosubmitme', function() {
 //});
 
 // click add to cart button
-$(document).on('click', '#add_to_cart', function () {
+$(document).on('click', '.add_to_cart', function () {
   pause_cart();
 });
 

--- a/app/assets/stylesheets/catalog/_index.css.scss
+++ b/app/assets/stylesheets/catalog/_index.css.scss
@@ -16,7 +16,7 @@
   }
 }
 
-#add_to_cart {
+.add_to_cart,.add_to_cart_disabled {
   position: absolute;
   bottom: 13px;
 }

--- a/app/views/catalog/_equipment_model_div.html.erb
+++ b/app/views/catalog/_equipment_model_div.html.erb
@@ -23,7 +23,7 @@
     </div>
     <% if equipment_model.model_restricted?(cart.reserver_id) %>
       <div class="add_to_cart_box">
-        <%= button_tag "Add to Cart", :class => "btn disabled", :id => 'add_to_cart' %>
+        <%= button_tag "Add to Cart", :class => "btn disabled add_to_cart_disabled"%>
         <%= link_to "#qualifications_modal", class: 'not-qualified-icon', rel: "tooltip", title: "Not Qualified (click for more info)", :"data-toggle" => 'modal' do %>
           <i class="icon-warning-sign"></i>
         <% end %>
@@ -43,11 +43,11 @@
 
     <% elsif equipment_model.num_available(cart.start_date, cart.due_date) > 0 %>
       <div class="add_to_cart_box">
-        <%= link_to "Add to Cart", add_to_cart_path(equipment_model), :method => :put, :remote => true, :class => "btn", :id => "add_to_cart" %>
+        <%= link_to "Add to Cart", add_to_cart_path(equipment_model), :method => :put, :remote => true, :class => "btn add_to_cart" %>
       </div>
     <% else %>
       <div class="add_to_cart_box">
-        <%#= button_tag "Add to Cart", :class => "btn disabled", :id => 'add_to_cart' %>
+        <%= button_tag "Add to Cart", :class => "btn disabled add_to_cart_disabled"%>
         <%# this line is commented out to remove the button when no equipment is available, see issue 555 %>
       </div>
     <% end %>


### PR DESCRIPTION
Users can click "add to cart" even though the button is stylized as disabled. We didn't notice this before #528 was implemented but now it's obvious that it triggers an infinitely loading js.

We could probably just remove the button for items that aren't available...
