### PR TITLE
Enable editing of email field in quick-create user

### DIFF
--- a/app/views/users/_short_form.html.erb
+++ b/app/views/users/_short_form.html.erb
@@ -15,7 +15,7 @@
       <%= f.input :phone, hint: "format like (555) 555-5555" %>
     <% end %>
 
-    <%= f.input :email, :readonly => true %>
+    <%= f.input :email %>
     <%= f.input :affiliation %>
 
     <%= hidden_field_tag(:from_cart, true) %>


### PR DESCRIPTION
From Derek:

> Can we enable editing the email field when creating new users in Reservations?

![image](https://cloud.githubusercontent.com/assets/6618711/3293092/fdc6f970-f596-11e3-890f-42d31310bae8.png)

> Summer students don't have a Yale email address so we need to be able to enter their personal email address in this field. Example in this case is netid=sc2262. 

I told him staff and admins can create users via users->new user but there's not really a reason to disallow editing of these fields, especially since users can go and edit their name, email, etc. after their account is created anyway (though maybe this will change in #528). At the very least though, their email should be editable.
