### PR TITLE
Blackout date flash messages are incorrect

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -75,7 +75,8 @@ class Cart
 
   # Sets start date and updates all CartReservations to match
   def set_start_date(date)
-    if date >= Date.today 
+    date = date.to_time.in_time_zone
+    if date >= Date.today
       @start_date = date
       fix_due_date
       cart_reservations.update_all({start_date: @start_date, due_date: @due_date})
@@ -84,6 +85,7 @@ class Cart
 
   # Sets due date and updates all CartReservations to match
   def set_due_date(date)
+    date = date.to_time.in_time_zone
     @due_date = date
     fix_due_date
     cart_reservations.update_all({start_date: @start_date, due_date: @due_date})


### PR DESCRIPTION
While testing a different bug I noticed that the flash messages from the blackout date validations are just wrong. I created a blackout date for one day on 04/30/2014 and then made the start and end dates of my reservation 05/01/2014 (see below). Both of these gave errors that mentioned the actual blackout date but don't actually make sense. I think the entire blackout date validation system needs to be verified, on top of a complete refactoring of the blackout date system :-P.

![selection_004](https://cloud.githubusercontent.com/assets/901808/2824817/309e4bec-cf3a-11e3-8045-8683f045a14d.png)
