### PR TITLE
Redirect loop when logging in as new user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from CanCan::AccessDenied do |exception|
     flash[:error] = "Sorry, that action or page is restricted."
-    if current_user.view_mode == 'banned'
+    if current_user && current_user.view_mode == 'banned'
       flash[:error] = "That action is restricted; it looks like you're a banned user! Talk to your administrator, maybe they'll be willing to lift your restriction."
     end
     #redirect_to request.referer ? request.referer : main_app.root_url
@@ -114,7 +114,7 @@ class ApplicationController < ActionController::Base
 							  (see #{ActionController::Base.helpers.link_to('here','https://yalestc.github.io/reservations/')} for details)."
 	end
   end
-  
+
   def fix_cart_date
     cart.set_start_date(Date.today) if cart.start_date < Date.today
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,5 +49,7 @@ class Ability
           cannot :view_as, :superuser
       end
     end
+  else
+    can :create, User
   end
 end


### PR DESCRIPTION
If a new user attempts to login, CanCan will boot them off the users/new page because they don't have permission. However, the filter will direct them to users/new if they don't have an account, thus triggering a redirect loop.
