### PR TITLE
Cart dates totally broken on any page besides catalog

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,9 +38,10 @@ class Ability
             r.checked_in ==  nil
             r.checked_out != nil
           end
+          can :update_cart, :all
         when 'banned'
           #cannot :create, Reservation
-	    end
+      end
       case user.role
         when 'superuser'
           can :change, :views


### PR DESCRIPTION
Both on master (3.2.0) and development (~3.3.0) changing the dates on the cart never succeeds. The spinner spins (forever, I suppose) and the cart dates are never actually updated.

GG

Edit: in some cases a 500 internal server runtime error is triggered via the javascript console, which of course has to do with dates and times

`ArgumentError (comparison of Date with ActiveSupport::TimeWithZone failed):`

Edit 2: on master it appears that changing the cart date never succeeds!! Can someone try to replicate this, it is very odd behavior

Edit 3: i suspect this is a db issue
