### PR TITLE
Running ActiveAdmin in development is slow

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Reservations::Application.routes.draw do
   root :to => 'catalog#index'
-  
-  ActiveAdmin.routes(self)
+
+  ActiveAdmin.routes(self) unless Rails.env.development?
+
 
   get "log/index"
   get "log/version/:id" => "log#version", as: :version_view


### PR DESCRIPTION
Running AA in dev causes memory leaks and slows down development (this is a documented bug). Commenting out the ActiveAdmin line in `config/routes.rb` effectively disables AA; I propose we prepend this with `unless Rails.env = development` to disable it in development and run it in production
