### PR TITLE
Refactor CSS for calendar view controls

### DIFF
--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -82,18 +82,17 @@ function shiftCalendar(offset) {
   var date_max = new Date($('#res-data').data('dateMax'));
   var max = $('#res-data').data('max');
   week_start.setDate(week_start.getDate() + offset);
-  block_left = week_start <= today
+  block_left = week_start <= today;
   if (block_left) {
     week_start.setTime(today.getTime());
   }
-  $('.c-left').css('opacity',block_left? 0.2 : 1.0)
-              .css('cursor',block_left? 'default' : 'pointer');
-  block_right = week_start >= date_max
+  $('.c-left').children().toggleClass('disabled-control',block_left);
+  
+  block_right = week_start >= date_max;
   if (block_right) {
     week_start.setTime(date_max.getTime());
   }
-  $('.c-right').css('opacity',block_right? 0.2 : 1.0)
-               .css('cursor', block_right? 'default' : 'pointer');
+  $('.c-right').children().toggleClass('disabled-control',block_right);
   renderCalendar(reservations,week_start,max,blackouts);
 };
 

--- a/app/assets/stylesheets/equipment_models/_show.css.scss
+++ b/app/assets/stylesheets/equipment_models/_show.css.scss
@@ -38,18 +38,16 @@ $border-att: 1px solid darken($bodyBackground, 20%);
 
 .c-left {
   float: left;
-  cursor: pointer;
 }
 
 .c-right {
   float: right;
-  cursor: pointer;
 }
 
 .control {
+  cursor:pointer;
   margin-left:3px;
   margin-right: 3px;
-  text-shadow: 2px;
   opacity: 0.8;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -59,7 +57,7 @@ $border-att: 1px solid darken($bodyBackground, 20%);
   user-select: none;
 }
 
-.control:hover{
+.control:not(.disabled-control):hover{
   opacity: 1.0;
 }
 
@@ -69,6 +67,11 @@ $border-att: 1px solid darken($bodyBackground, 20%);
 
 .lite {
   opacity: 0.7;
+}
+
+.disabled-control {
+  opacity:0.2;
+  cursor:default;
 }
 
 .btn-large {


### PR DESCRIPTION
- Take the styling currently applied as a style attribute on the controls and convert them into CSS classes that jQuery adds or removes as needed.
- Remove the hover state for disabled controls.
