### PR TITLE
add fedora database.yml file

### DIFF
--- a/config/database.yml.example.fedora
+++ b/config/database.yml.example.fedora
@@ -1,0 +1,47 @@
+# Tested with Fedora 20 on 20140705.
+#
+# Note that MySQL has been superceded by
+# drop-in replacement MariaDB.
+#
+# If server fails to connect, run:
+# $ sudo yum remove mariadb-server && sudo \
+#   rm -rf /usr/lib64/mysql /var/lib/mysql \
+#   && sudo yum install mariadb-server
+#
+# Make sure to enable the systemd service:
+# $ sudo systemctl enable mariadb.service \
+#   && sudo systemctl start mariadb.service
+#
+development:
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: reservations_development
+  pool: 5
+  username: root
+  password:
+  socket: /var/lib/mysql/mysql.sock
+  host: localhost
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: reservations_test
+  pool: 5
+  username: root
+  password:
+  socket: /var/lib/mysql/mysql.sock
+
+production:
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: reservations_production
+  pool: 5
+  username: root
+  password:
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
This database.yml example file enables the MySQL backend on Fedora 20.
