### PR TITLE
Fixing typo in ability.rb

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,8 +49,8 @@ class Ability
           can :change, :views
           cannot :view_as, :superuser
       end
+    else
+      can :create, User
     end
-  else
-    can :create, User
   end
 end


### PR DESCRIPTION
RSpec provided the following warning: "/Users/Simon/Coding/reservations/app/models/ability.rb:55: warning: else without rescue is useless". It turned out that our else statement in the file was off-by-block. This edit fixes it.
