### PR TITLE
add parallel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem 'awesome_print'
   gem 'ruby-progressbar'
   gem 'codeclimate-test-reporter'
+  gem 'parallel_tests'
 end
 
 # Gems used only for assets and not required
@@ -76,7 +77,7 @@ group :assets do
 end
 
 group :development do
-	gem 'thin'
+  gem 'thin'
   gem 'pry'
   gem 'pry-rails'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,9 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.0)
       mime-types
+    parallel (1.0.0)
+    parallel_tests (1.0.0)
+      parallel
     permanent_records (3.1.6)
       activerecord (>= 3.0.0)
     polyamorous (0.5.0)
@@ -402,6 +405,7 @@ DEPENDENCIES
   nilify_blanks
   paper_trail!
   paperclip
+  parallel_tests
   permanent_records
   pry
   pry-byebug

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 require 'rake/dsl_definition'
 require 'rake'
-
+begin; require 'parallel_tests/tasks'; rescue LoadError; end
 Reservations::Application.load_tasks


### PR DESCRIPTION
From #668 

Setup:

Make sure your database.yml looks something like this:

```
test: &TEST
  adapter: mysql2
  encoding: utf8
  reconnect: false
  database: reservations_test<%= ENV['TEST_ENV_NUMBER'] %>
  pool: 5
  username: root
  password:
  socket: /var/run/mysqld/mysqld.sock
```

```
rake parallel:create
rake parallel:migrate
rake parallel:prepare
```

Then to run tests (don't use Spork, as parallel is incompatible: parallel is still faster though, plus once we upgrade to rails 4.1 we'll be using spring anyway)

```
rake parallel:spec
```
