### PR TITLE
Database_cleaner gem setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development, :test do
   gem 'ruby-progressbar'
   gem 'codeclimate-test-reporter'
   gem 'parallel_tests'
+  gem 'database_cleaner'
 end
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     coffee-script-source (1.6.3)
     columnize (0.8.9)
     daemons (1.1.9)
+    database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     devise (3.2.4)
@@ -385,6 +386,7 @@ DEPENDENCIES
   cocoon
   codeclimate-test-reporter
   coffee-rails
+  database_cleaner
   dynamic_form
   factory_girl_rails
   ffaker

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,18 @@ Spork.prefork do
     # the seed, which is printed after each run.
     #     --seed 1234
     config.order = "random"
+
+    # DatabaseCleaner setup
+    config.before(:suite) do
+      DatabaseCleaner.strategy = :transaction
+      DatabaseCleaner.clean_with(:truncation)
+    end
+
+    config.around(:each) do |example|
+      DatabaseCleaner.cleaning do
+        example.run
+      end
+    end
   end
 
 end


### PR DESCRIPTION
As per #593. In my tests so far, it removes the need to run rake test:prepare (other than before the first run), but we'll see how much it helps.
