### PR TITLE
remove ability to create users from patron ability

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,7 +29,7 @@ class Ability
             can :override, :checkout_errors
           end
         when 'normal' || 'checkout'
-          can [:create,:update,:show], User, :id => user.id
+          can [:update,:show], User, :id => user.id
           can :read, EquipmentModel
           can [:read,:create], Reservation, :reserver_id => user.id
           can :destroy, Reservation, :reserver_id => user.id, :checked_out => nil


### PR DESCRIPTION
this needs to be merged in before sunday afternoon, or whenever 3.4 begins deployment
