### PR TITLE
Revert "remove ability to create users from patron ability"

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,7 +29,7 @@ class Ability
             can :override, :checkout_errors
           end
         when 'normal' || 'checkout'
-          can [:update,:show], User, :id => user.id
+          can [:create,:update,:show], User, :id => user.id
           can :read, EquipmentModel
           can [:read,:create], Reservation, :reserver_id => user.id
           can :destroy, Reservation, :reserver_id => user.id, :checked_out => nil


### PR DESCRIPTION
Reverts YaleSTC/reservations#824

We need to back this out; it seems to be preventing patrons from editing their user profiles.
