### PR TITLE
Revert "Revert "remove ability to create users from patron ability""

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,7 +29,7 @@ class Ability
             can :override, :checkout_errors
           end
         when 'normal' || 'checkout'
-          can [:create,:update,:show], User, :id => user.id
+          can [:update,:show], User, :id => user.id
           can :read, EquipmentModel
           can [:read,:create], Reservation, :reserver_id => user.id
           can :destroy, Reservation, :reserver_id => user.id, :checked_out => nil


### PR DESCRIPTION
Reverts YaleSTC/reservations#828

Nevermind, it appears patrons can't submit the edit user page irrespective of this commit. (I've rebooted the entire VM and I'm still getting it.)

@squidgetx, any ideas what's changed recently wrt the user edit form?
