### PR TITLE
update checkoutable to include late reservations

### DIFF
--- a/app/models/reservation_scopes.rb
+++ b/app/models/reservation_scopes.rb
@@ -20,6 +20,7 @@ module ReservationScopes
       scope :returned_overdue, lambda { where("due_date < checked_in").returned }
       scope :missed, lambda { where("due_date < ?", Date.current.to_time).untouched.recent }
       scope :upcoming, lambda { where("start_date = ?", Date.current.to_time).reserved.user_sort }
+      scope :checkoutable, lambda { where("start_date <= ?", Date.current.to_time).reserved }
       scope :starts_on_days, lambda { |start_date, end_date|  where(start_date: start_date..end_date) }
       scope :reserved_on_date, lambda { |date|  where("start_date <= ? and due_date >= ?", Time.zone.parse(date.to_s), Time.zone.parse(date.to_s)).finalized }
       scope :for_eq_model, lambda { |eq_model| where(equipment_model_id: eq_model.id).finalized }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,7 +91,7 @@ class User < ActiveRecord::Base
   end
 
   def due_for_checkout
-    self.reservations.upcoming
+    self.reservations.checkoutable
   end
 
   def due_for_checkin


### PR DESCRIPTION
resolves a latenight issue where reservations that did not start on the current day were not being populated in the checkout set. See issue #844 
