### PR TITLE
resolves #857 on v3.4

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,7 +19,7 @@ class Ability
           unless AppConfig.first.checkout_persons_can_edit
             cannot :update, Reservation
           end
-          can [:read,:update,:create,:find], User
+          can [:read,:update,:create,:find,:autocomplete_user_last_name], User
           can :read, EquipmentObject
           can :read, EquipmentModel
           if AppConfig.first.override_on_create


### PR DESCRIPTION
resolves #857 by giving checkoutpersons the permissions to use autocomplete for the Users search.
