### PR TITLE
Convert specs to RSpec 3.0.3 syntax with Transpec

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140724194636) do
+ActiveRecord::Schema.define(version: 20140727232238) do
 
   create_table "announcements", force: true do |t|
     t.text     "message"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20140724194636) do
     t.boolean  "override_on_create",                                 default: false
     t.boolean  "override_at_checkout",                               default: false
     t.integer  "blackout_exp_time"
+    t.text     "request_text"
   end
 
   create_table "blackouts", force: true do |t|

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
 shared_examples_for 'page success' do
-  it { should respond_with(:success) }
-  it { should_not set_the_flash }
+  it { is_expected.to respond_with(:success) }
+  it { is_expected.not_to set_the_flash }
 end
 
 shared_examples_for 'access denied' do
-  it { should redirect_to(root_url) }
-  it { should set_the_flash }
+  it { is_expected.to redirect_to(root_url) }
+  it { is_expected.to set_the_flash }
 end
 
-describe AnnouncementsController do
+describe AnnouncementsController, :type => :controller do
   before(:all) {
     @app_config = FactoryGirl.create(:app_config)
   }
   before {
-    @controller.stub(:first_time_user).and_return(:nil)
+    allow(@controller).to receive(:first_time_user).and_return(:nil)
   }
 
  describe 'with admin' do
     before do
-      @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+      allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
     end
     context 'GET index' do
       before do
         get:index
       end
       it_behaves_like 'page success'
-      it { should render_template(:index) }
+      it { is_expected.to render_template(:index) }
       it 'should assign @announcements to all Announcements' do
         expect(assigns(:announcements)).to eq(Announcement.all)
       end
@@ -37,18 +37,18 @@ describe AnnouncementsController do
         get :new
       end
       it 'sets the default announcement' do
-        assigns(:announcement)[:starts_at].should eq(Time.current.midnight)
-        assigns(:announcement)[:ends_at].should eq(Time.current.midnight + 24.hours)
+        expect(assigns(:announcement)[:starts_at]).to eq(Time.current.midnight)
+        expect(assigns(:announcement)[:ends_at]).to eq(Time.current.midnight + 24.hours)
       end
       it_behaves_like 'page success'
-      it { should render_template(:new) }
+      it { is_expected.to render_template(:new) }
     end
     context 'GET edit' do
       before do
         get :edit, id: FactoryGirl.create(:announcement)
       end
       it_behaves_like 'page success'
-      it { should render_template(:edit) }
+      it { is_expected.to render_template(:edit) }
     end
     context 'POST create' do
       context 'with correct params' do
@@ -57,14 +57,14 @@ describe AnnouncementsController do
           post :create, announcement: @attributes
         end
         it 'should create the new announcement' do
-          Announcement.find(assigns(:announcement)).should_not be_nil
+          expect(Announcement.find(assigns(:announcement))).not_to be_nil
         end
         it 'should pass the correct params' do
-          assigns(:announcement)[:starts_at].to_date.should eq(@attributes[:starts_at].to_date)
-          assigns(:announcement)[:ends_at].to_date.should eq(@attributes[:ends_at].to_date)
+          expect(assigns(:announcement)[:starts_at].to_date).to eq(@attributes[:starts_at].to_date)
+          expect(assigns(:announcement)[:ends_at].to_date).to eq(@attributes[:ends_at].to_date)
         end
-        it { should redirect_to(announcements_path) }
-        it { should set_the_flash }
+        it { is_expected.to redirect_to(announcements_path) }
+        it { is_expected.to set_the_flash }
       end
       context 'with incorrect params' do
         before do
@@ -72,7 +72,7 @@ describe AnnouncementsController do
           @attributes[:ends_at] = Date.yesterday
           post :create, announcement: @attributes
         end
-        it { should render_template(:new) }
+        it { is_expected.to render_template(:new) }
       end
     end
     context 'PUT update' do
@@ -82,7 +82,7 @@ describe AnnouncementsController do
         put :update, id: FactoryGirl.create(:announcement), announcement: @new_attributes
       end
       it 'updates the announcement' do
-        assigns(:announcement)[:message].should eq(@new_attributes[:message])
+        expect(assigns(:announcement)[:message]).to eq(@new_attributes[:message])
       end
     end
     context 'DELETE destroy' do
@@ -90,14 +90,14 @@ describe AnnouncementsController do
         delete :destroy, id: FactoryGirl.create(:announcement)
       end
       it 'should delete the announcement' do
-        Announcement.where(id:  assigns(:announcement)[:id]).should be_empty
+        expect(Announcement.where(id:  assigns(:announcement)[:id])).to be_empty
       end
-      it { should redirect_to(announcements_path) }
+      it { is_expected.to redirect_to(announcements_path) }
     end
   end
   context 'is not admin' do
     before do
-      @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+      allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
       @announcement = FactoryGirl.create(:announcement)
       @attributes = FactoryGirl.attributes_for(:announcement)
     end

--- a/spec/controllers/app_configs_controller_spec.rb
+++ b/spec/controllers/app_configs_controller_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 # match '/create_app_configs' => 'application_setup#create_app_configs', :as => :create_app_configs
 
 
-describe AppConfigsController do
+describe AppConfigsController, :type => :controller do
 
   describe 'GET edit' do
     context 'app_config exists already' do
@@ -18,31 +18,31 @@ describe AppConfigsController do
       end
       context 'user is admin' do
         before(:each) do
-          controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+          allow(controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
           get :edit
         end
-        it { should render_template(:edit) }
-        it { should respond_with(:success) }
-        it { should_not set_the_flash }
+        it { is_expected.to render_template(:edit) }
+        it { is_expected.to respond_with(:success) }
+        it { is_expected.not_to set_the_flash }
         it 'should assign @app_config variable to the first appconfig in the db' do
           expect(assigns(:app_config)).to eq(AppConfig.first)
         end
       end
       context 'user is not admin' do
         before(:each) do
-          controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+          allow(controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
           get :edit
         end
-        it { should redirect_to(root_path) }
+        it { is_expected.to redirect_to(root_path) }
       end
     end
     context 'app_config does not exist yet' do
       before(:each) do
         get :edit
       end
-      it { should respond_with(:success) }
-      it { should set_the_flash }
-      it { should render_template('application_setup/index') }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to render_template('application_setup/index') }
     end
   end
 
@@ -54,7 +54,7 @@ describe AppConfigsController do
       end
       context 'user is admin' do
         before (:each) do
-          controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+          allow(controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
           @params = FactoryGirl.attributes_for(:app_config) # Except paperclip attributes that trigger MassAssignment errors
             .reject {|k,v| [:favicon_file_name, :favicon_content_type, :favicon_file_size, :favicon_updated_at].include? k}
         end
@@ -102,10 +102,10 @@ describe AppConfigsController do
       end
       context 'user is not admin' do
         before(:each) do
-          controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+          allow(controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
           post :update
         end
-        it { should redirect_to(root_path) }
+        it { is_expected.to redirect_to(root_path) }
       end
     end
     context 'app_config does not exist yet' do
@@ -115,9 +115,9 @@ describe AppConfigsController do
       before(:each) do
         post :update
       end
-      it { should respond_with(:success) }
-      it { should set_the_flash }
-      it { should render_template('application_setup/index') }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to render_template('application_setup/index') }
     end
   end
 end

--- a/spec/controllers/app_configs_controller_spec_old.rb
+++ b/spec/controllers/app_configs_controller_spec_old.rb
@@ -9,13 +9,13 @@ require 'spec_helper'
 # match '/create_app_configs' => 'application_setup#create_app_configs', :as => :create_app_configs
 
 
-describe AppConfigsController do
+describe AppConfigsController, :type => :controller do
   before(:each) do
     @app_config = FactoryGirl.create(:app_config)
   end
   context 'User is not admin' do
     before (:each) do
-      @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+      allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
     end
 
     describe 'GET edit' do
@@ -31,13 +31,13 @@ describe AppConfigsController do
     end
 
     after(:each) do
-      response.should redirect_to(root_path)
+      expect(response).to redirect_to(root_path)
     end
   end
 
   context 'User is admin' do
     before (:each) do
-      @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+      allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
     end
 
     describe 'GET edit' do
@@ -51,9 +51,9 @@ describe AppConfigsController do
           get :edit
           expect(assigns(:app_config)).to eq(AppConfig.first)
         end
-        it { should respond_with(:success) }
-        it { should render_template(:edit) }
-        it { should_not set_the_flash }
+        it { is_expected.to respond_with(:success) }
+        it { is_expected.to render_template(:edit) }
+        it { is_expected.not_to set_the_flash }
       end
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -36,31 +36,31 @@ class TestController < ApplicationController
   end
 end
 
-describe TestController do
+describe TestController, :type => :controller do
   before(:each) do
     @app_config = FactoryGirl.create(:app_config)
     @first_user = FactoryGirl.create(:user) # this is to ensure that all before_filters are run
-    controller.stub(:app_setup_check)
-    controller.stub(:load_configs)
-    controller.stub(:seen_app_configs)
-    controller.stub(:first_time_user)
-    controller.stub(:cart)
-    controller.stub(:fix_cart_date)
-    controller.stub(:set_view_mode)
-    controller.stub(:current_user)
-    controller.stub(:make_cart_compatible)
+    allow(controller).to receive(:app_setup_check)
+    allow(controller).to receive(:load_configs)
+    allow(controller).to receive(:seen_app_configs)
+    allow(controller).to receive(:first_time_user)
+    allow(controller).to receive(:cart)
+    allow(controller).to receive(:fix_cart_date)
+    allow(controller).to receive(:set_view_mode)
+    allow(controller).to receive(:current_user)
+    allow(controller).to receive(:make_cart_compatible)
   end
 
   describe 'make_cart_compatible' do
     before(:each) do
-      controller.unstub(:make_cart_compatible)
+      allow(controller).to receive(:make_cart_compatible).and_call_original
     end
     it 'replaces the cart if items is an Array' do
       session[:cart] = FactoryGirl.build(:cart, items: [1])
       get :index
-      session[:cart].items.should be_a(Hash)
-      session[:cart].items.should be_empty
-      session[:cart].items.should_not be_a(Array)
+      expect(session[:cart].items).to be_a(Hash)
+      expect(session[:cart].items).to be_empty
+      expect(session[:cart].items).not_to be_a(Array)
     end
     it 'leaves the cart alone if items is a Hash' do
       session[:cart] = FactoryGirl.build(:cart_with_items)
@@ -70,39 +70,39 @@ describe TestController do
 
   describe 'app_setup_check' do
     before(:each) do
-      controller.unstub(:app_setup_check)
+      allow(controller).to receive(:app_setup_check).and_call_original
     end
     context 'user and appconfig in the db' do
       before(:each) do
         get :index
       end
-      it { should respond_with(:success) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.not_to set_the_flash }
     end
     context 'no app_config' do
       before(:each) do
         AppConfig.delete_all
         get :index
       end
-      it { should set_the_flash }
-      it { should render_template('application_setup/index') }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to render_template('application_setup/index') }
     end
     context 'no user in the db' do
       before(:each) do
         User.delete_all
         get :index
       end
-      it { should set_the_flash }
-      it { should render_template('application_setup/index') }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to render_template('application_setup/index') }
     end
   end
 
   describe 'seen_app_configs' do
     before(:each) do
-      controller.stub(:load_configs).and_return(@app_config)
-      controller.unstub(:seen_app_configs)
+      allow(controller).to receive(:load_configs).and_return(@app_config)
+      allow(controller).to receive(:seen_app_configs).and_call_original
       @admin = FactoryGirl.create(:admin)
-      controller.stub(:current_user).and_return(@admin)
+      allow(controller).to receive(:current_user).and_return(@admin)
     end
     context 'app configs have not been viewed' do
       before(:each) do
@@ -110,23 +110,23 @@ describe TestController do
         @app_config = FactoryGirl.create(:app_config, viewed: false)
         get :index
       end
-      it { should set_the_flash }
-      it { should respond_with(:redirect) }
-      it { should redirect_to(edit_app_configs_path) }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to respond_with(:redirect) }
+      it { is_expected.to redirect_to(edit_app_configs_path) }
     end
     context 'app configs have been viewed' do
       before(:each) do
         get :index
       end
-      it { should_not set_the_flash }
-      it { should respond_with(:success) }
-      it { should_not redirect_to(edit_app_configs_path) }
+      it { is_expected.not_to set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.not_to redirect_to(edit_app_configs_path) }
     end
   end
 
   describe 'load_configs' do
     it 'should set @app_configs to the first AppConfig' do
-      controller.unstub(:load_configs)
+      allow(controller).to receive(:load_configs).and_call_original
       get :index
       expect(assigns(:app_configs)).to eq(AppConfig.first)
     end
@@ -135,63 +135,63 @@ describe TestController do
   describe 'first_time_user' do
     before(:each) do
       @user = FactoryGirl.create(:user)
-      controller.stub(:current_user).and_return(@user)
-      controller.unstub(:first_time_user)
+      allow(controller).to receive(:current_user).and_return(@user)
+      allow(controller).to receive(:first_time_user).and_call_original
     end
     context 'current_user exists' do
       before(:each) do
         get :index
       end
-      it { should_not set_the_flash }
+      it { is_expected.not_to set_the_flash }
       it 'should not redirect' do
-        response.should_not be_redirect
+        expect(response).not_to be_redirect
       end
     end
     context 'current_user is nil' do
       before(:each) do
-        controller.stub(:current_user).and_return(nil)
+        allow(controller).to receive(:current_user).and_return(nil)
         get :index
       end
       context 'params[:action] = "terms_of_service"' do
         before(:each) do
           get :terms_of_service
         end
-        it { should_not set_the_flash }
+        it { is_expected.not_to set_the_flash }
         it 'should not redirect' do
-          response.should_not be_redirect
+          expect(response).not_to be_redirect
         end
       end
-      it { should set_the_flash }
-      it { should redirect_to(new_user_path) }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to redirect_to(new_user_path) }
     end
   end
 
   describe 'cart' do
     before(:each) do
-      controller.unstub(:cart)
+      allow(controller).to receive(:cart).and_call_original
       @user = FactoryGirl.create(:user)
     end
     it 'makes a new cart record for session[:cart] if !cart' do
       get :index
-      session[:cart].should be_new_record
-      session[:cart].kind_of?(Cart).should be_truthy
+      expect(session[:cart]).to be_new_record
+      expect(session[:cart].kind_of?(Cart)).to be_truthy
     end
     it 'returns session[:cart] if cart.reserver_id' do
       session[:cart] = Cart.new
       session[:cart].reserver_id = @user.id
       get :index
-      session[:cart].reserver_id.should == @user.id
+      expect(session[:cart].reserver_id).to eq(@user.id)
     end
     it 'sets the session[:cart].reserver_id to current_user.id if !cart.reserver_id && current_user' do
-      controller.stub(:current_user).and_return(@user)
+      allow(controller).to receive(:current_user).and_return(@user)
       session[:cart] = Cart.new
       get :index
-      session[:cart].reserver_id.should eq(@user.id)
+      expect(session[:cart].reserver_id).to eq(@user.id)
     end
     it 'returns session[:cart] without a reserver_id if !cart.reserver_id && !current_user' do
       session[:cart] = Cart.new
       get :index
-      session[:cart].reserver_id.should be_nil
+      expect(session[:cart].reserver_id).to be_nil
     end
   end
 
@@ -201,7 +201,7 @@ describe TestController do
 
   describe 'current_user' do
     before(:each) do
-      controller.unstub(:current_user)
+      allow(controller).to receive(:current_user).and_call_original
     end
     context '@current_user already exists' do
       it 'should return the current user' do
@@ -231,38 +231,38 @@ describe TestController do
 
   describe 'fix_cart_date' do
     before(:each) do
-      controller.unstub(:fix_cart_date)
+      allow(controller).to receive(:fix_cart_date).and_call_original
       session[:cart] = Cart.new
-      controller.stub(:cart).and_return(session[:cart])
+      allow(controller).to receive(:cart).and_return(session[:cart])
     end
     it 'changes cart.start_date to today if date is in the past' do
       session[:cart].start_date = Date.yesterday
       get :index
-      session[:cart].start_date.should eq(Date.current)
+      expect(session[:cart].start_date).to eq(Date.current)
     end
     it 'does not change the start_date if date is in the future' do
       session[:cart].start_date = Date.tomorrow
       get :index
-      session[:cart].start_date.should eq(Date.tomorrow)
-      session[:cart].start_date.should_not eq(Date.current)
+      expect(session[:cart].start_date).to eq(Date.tomorrow)
+      expect(session[:cart].start_date).not_to eq(Date.current)
     end
   end
 
 end
 
-describe ApplicationController do
+describe ApplicationController, :type => :controller do
   before(:each) do
     @app_config = FactoryGirl.create(:app_config)
     @first_user = FactoryGirl.create(:user) # this is to ensure that all before_filters are run
-    controller.stub(:app_setup_check)
-    controller.stub(:load_configs)
-    controller.stub(:seen_app_configs)
-    controller.stub(:first_time_user)
-    controller.stub(:cart)
-    controller.stub(:fix_cart_date)
-    controller.stub(:set_view_mode)
-    controller.stub(:current_user)
-    controller.stub(:make_cart_compatible)
+    allow(controller).to receive(:app_setup_check)
+    allow(controller).to receive(:load_configs)
+    allow(controller).to receive(:seen_app_configs)
+    allow(controller).to receive(:first_time_user)
+    allow(controller).to receive(:cart)
+    allow(controller).to receive(:fix_cart_date)
+    allow(controller).to receive(:set_view_mode)
+    allow(controller).to receive(:current_user)
+    allow(controller).to receive(:make_cart_compatible)
   end
 
   #TODO - This may involve rewriting the method somewhat
@@ -286,13 +286,13 @@ describe ApplicationController do
 
         put :update_cart, cart: {start_date_cart: new_start, due_date_cart: new_end}, reserver_id: @new_reserver.id
 
-        session[:cart].start_date.should eq(new_start)
-        session[:cart].due_date.should eq(new_end)
-        session[:cart].reserver_id.should eq(@new_reserver.id.to_s)
+        expect(session[:cart].start_date).to eq(new_start)
+        expect(session[:cart].due_date).to eq(new_end)
+        expect(session[:cart].reserver_id).to eq(@new_reserver.id.to_s)
       end
 
       it 'should not set the flash' do
-        flash.should be_empty
+        expect(flash).to be_empty
       end
     end
 
@@ -303,7 +303,7 @@ describe ApplicationController do
 
         put :update_cart, cart: {start_date_cart: new_start.strftime('%m/%d/%Y'), due_date_cart: new_end.strftime('%m/%d/%Y')}, reserver_id: @new_reserver.id
 
-        flash.should_not be_empty
+        expect(flash).not_to be_empty
      end
    end
   end
@@ -315,10 +315,10 @@ describe ApplicationController do
       delete :empty_cart
     end
     it 'empties the cart' do
-      session[:cart].items.should be_empty
+      expect(session[:cart].items).to be_empty
     end
-    it { should redirect_to(root_path) }
-    it { should set_the_flash }
+    it { is_expected.to redirect_to(root_path) }
+    it { is_expected.to set_the_flash }
   end
 
   describe 'GET logout' do
@@ -326,7 +326,7 @@ describe ApplicationController do
       @user = FactoryGirl.create(:user)
       controller.instance_variable_set(:@current_user, @user)
       get :logout
-      assigns(:current_user).should be_nil
+      expect(assigns(:current_user)).to be_nil
     end
     it 'should log the user out of CAS' # TODO: figure out how to test this
   end
@@ -337,7 +337,7 @@ describe ApplicationController do
       controller.instance_variable_set(:@app_configs, @app_config)
       get :terms_of_service
     end
-    it { should render_template('terms_of_service/index') }
+    it { is_expected.to render_template('terms_of_service/index') }
     it 'assigns @app_config.terms_of_service to @tos' do
       expect(assigns(:tos)).to eq(@app_config.terms_of_service)
     end
@@ -362,7 +362,7 @@ describe ApplicationController do
     before(:each) do
       get :markdown_help
     end
-    it { should render_template('shared/_markdown_help') }
+    it { is_expected.to render_template('shared/_markdown_help') }
     # TODO: not sure how to make sure that the js template is being rendered as well.
   end
 end

--- a/spec/controllers/blackouts_controller_spec.rb
+++ b/spec/controllers/blackouts_controller_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
 shared_examples_for 'page success' do
-  it { should respond_with(:success) }
-  it { should_not set_the_flash }
+  it { is_expected.to respond_with(:success) }
+  it { is_expected.not_to set_the_flash }
 end
 
 shared_examples_for 'access denied' do
-  it { should redirect_to(root_url) }
-  it { should set_the_flash }
+  it { is_expected.to redirect_to(root_url) }
+  it { is_expected.to set_the_flash }
 end
 
-describe BlackoutsController do
+describe BlackoutsController, :type => :controller do
   before(:all) {
     @app_config = FactoryGirl.create(:app_config)
   }
   before {
-    @controller.stub(:first_time_user).and_return(:nil)
+    allow(@controller).to receive(:first_time_user).and_return(:nil)
   }
 
   describe 'with admin' do
     before do
-      @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+      allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
     end
     context 'GET index' do
       before do
         get:index
       end
       it_behaves_like 'page success'
-      it { should render_template(:index) }
+      it { is_expected.to render_template(:index) }
       it 'should assign @blackouts to all blackouts' do
         expect(assigns(:blackouts)).to eq(Blackout.all)
       end
@@ -37,7 +37,7 @@ describe BlackoutsController do
         get :show, id: FactoryGirl.create(:blackout)
       end
       it_behaves_like 'page success'
-      it { should render_template(:show) }
+      it { is_expected.to render_template(:show) }
       context 'single blackout' do
         it 'should not display a set' do
           expect(assigns(:blackout_set) == nil)
@@ -53,7 +53,7 @@ describe BlackoutsController do
       it_behaves_like 'page success'
       context 'recurring blackout' do
         it 'should display the correct set' do
-          assigns(:blackout_set).uniq.sort.should eq(@blackout_set.uniq.sort)
+          expect(assigns(:blackout_set).uniq.sort).to eq(@blackout_set.uniq.sort)
         end
         # the above code doesn't work; i'm too much of an rspec newbie
       end
@@ -63,21 +63,21 @@ describe BlackoutsController do
         get :new
       end
       it_behaves_like 'page success'
-      it { should render_template(:new) }
+      it { is_expected.to render_template(:new) }
     end
     context 'GET new_recurring' do
       before do
         get :new_recurring
       end
       it_behaves_like 'page success'
-      it { should render_template(:new_recurring) }
+      it { is_expected.to render_template(:new_recurring) }
     end
     context 'GET edit' do
       before do
         get :edit, id: FactoryGirl.create(:blackout)
       end
       it_behaves_like 'page success'
-      it { should render_template(:edit) }
+      it { is_expected.to render_template(:edit) }
     end
     context 'POST create_recurring' do
       context 'with correct params' do
@@ -87,10 +87,10 @@ describe BlackoutsController do
           post :create_recurring, blackout: @attributes
         end
         it 'should create a set' do
-          Blackout.where(set_id: @new_set_id).should_not be_empty
+          expect(Blackout.where(set_id: @new_set_id)).not_to be_empty
         end
-        it { should redirect_to(blackouts_path) }
-        it { should set_the_flash }
+        it { is_expected.to redirect_to(blackouts_path) }
+        it { is_expected.to set_the_flash }
       end
       context 'with incorrect params' do
         before do
@@ -98,8 +98,8 @@ describe BlackoutsController do
           @attributes = FactoryGirl.attributes_for(:blackout, days: [""])
           post :create_recurring, blackout: @attributes
         end
-        it { should set_the_flash }
-        it { should render_template("new_recurring") }
+        it { is_expected.to set_the_flash }
+        it { is_expected.to render_template("new_recurring") }
       end
     end
     context 'POST create' do
@@ -109,16 +109,16 @@ describe BlackoutsController do
           post :create, blackout: @attributes
         end
         it 'should create the new blackout' do
-          Blackout.find(assigns(:blackout)).should_not be_nil
+          expect(Blackout.find(assigns(:blackout))).not_to be_nil
         end
         it 'should pass the correct params' do
-          assigns(:blackout)[:notice].should eq(@attributes[:notice])
-          assigns(:blackout)[:start_date].should eq(@attributes[:start_date])
-          assigns(:blackout)[:end_date].should eq(@attributes[:end_date])
-          assigns(:blackout)[:blackout_type].should eq(@attributes[:blackout_type])
+          expect(assigns(:blackout)[:notice]).to eq(@attributes[:notice])
+          expect(assigns(:blackout)[:start_date]).to eq(@attributes[:start_date])
+          expect(assigns(:blackout)[:end_date]).to eq(@attributes[:end_date])
+          expect(assigns(:blackout)[:blackout_type]).to eq(@attributes[:blackout_type])
         end
-        it { should redirect_to(blackout_path(assigns(:blackout))) }
-        it { should set_the_flash }
+        it { is_expected.to redirect_to(blackout_path(assigns(:blackout))) }
+        it { is_expected.to set_the_flash }
       end
       context 'with incorrect params' do
         before do
@@ -126,7 +126,7 @@ describe BlackoutsController do
           @attributes[:end_date] = Date.yesterday
           post :create, blackout: @attributes
         end
-        it { should render_template(:new) }
+        it { is_expected.to render_template(:new) }
       end
     end
     context 'PUT update' do
@@ -137,7 +137,7 @@ describe BlackoutsController do
           put :update, id: FactoryGirl.create(:blackout), blackout: @new_attributes
         end
         it 'updates the blackout' do
-          assigns(:blackout)[:notice].should eq(@new_attributes[:notice])
+          expect(assigns(:blackout)[:notice]).to eq(@new_attributes[:notice])
         end
       end
       context 'recurring blackout' do
@@ -147,10 +147,10 @@ describe BlackoutsController do
           put :update, id: FactoryGirl.create(:blackout, set_id: 1), blackout: @new_attributes
         end
         it 'updates the blackout' do
-          assigns(:blackout)[:notice].should eq(@new_attributes[:notice])
+          expect(assigns(:blackout)[:notice]).to eq(@new_attributes[:notice])
         end
         it 'sets the set_id to nil' do
-          assigns(:blackout)[:set_id].should be_nil
+          expect(assigns(:blackout)[:set_id]).to be_nil
         end
       end
     end
@@ -159,9 +159,9 @@ describe BlackoutsController do
         delete :destroy, id: FactoryGirl.create(:blackout)
       end
       it 'should delete the blackout' do
-        Blackout.where(id:  assigns(:blackout)[:id]).should be_empty
+        expect(Blackout.where(id:  assigns(:blackout)[:id])).to be_empty
       end
-      it { should redirect_to(blackouts_path) }
+      it { is_expected.to redirect_to(blackouts_path) }
     end
     context 'DELETE destroy recurring' do
       before do
@@ -170,15 +170,15 @@ describe BlackoutsController do
         delete :destroy_recurring, id: FactoryGirl.create(:blackout, set_id: 1)
       end
       it 'should delete the whole set' do
-        Blackout.where(set_id: @extra[:set_id]).should be_empty
+        expect(Blackout.where(set_id: @extra[:set_id])).to be_empty
       end
-      it { should set_the_flash }
-      it { should redirect_to(blackouts_path) }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to redirect_to(blackouts_path) }
     end
   end
   context 'is not admin' do
     before do
-      @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+      allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
       @blackout = FactoryGirl.create(:blackout)
       @attributes = FactoryGirl.attributes_for(:blackout)
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe CatalogController do
+describe CatalogController, :type => :controller do
   before(:each) do
     @app_config = FactoryGirl.create(:app_config)
     @user = FactoryGirl.create(:user)
     @cart = FactoryGirl.build(:cart, reserver_id: @user.id)
-    @controller.stub(:current_user).and_return(@user)
-    @controller.stub(:first_time_user).and_return(nil)
+    allow(@controller).to receive(:current_user).and_return(@user)
+    allow(@controller).to receive(:first_time_user).and_return(nil)
     #@controller.stub(:cart).and_return(session[@cart])
     #@controller.stub(:fix_cart_date)
   end
@@ -17,9 +17,9 @@ describe CatalogController do
     it 'sets @reserver_id to the current cart.reserver_id' do
       expect(assigns(:reserver_id)).to eq(@user.id)
     end
-    it { should respond_with(:success) }
-    it { should render_template(:index) }
-    it { should_not set_the_flash }
+    it { is_expected.to respond_with(:success) }
+    it { is_expected.to render_template(:index) }
+    it { is_expected.not_to set_the_flash }
   end
   describe 'PUT add_to_cart' do
     context 'valid equipment_model selected' do
@@ -34,20 +34,20 @@ describe CatalogController do
 
       end
       it 'should set flash[:error] if errors exist' do
-        @cart.stub(:validate_items).and_return("test")
-        @cart.stub(:validate_dates_and_items).and_return("test2")
-        flash[:error].should_not be_nil
+        allow(@cart).to receive(:validate_items).and_return("test")
+        allow(@cart).to receive(:validate_dates_and_items).and_return("test2")
+        expect(flash[:error]).not_to be_nil
       end
-      it { should redirect_to(root_path) }
+      it { is_expected.to redirect_to(root_path) }
     end
     context 'invalid equipment_model selected' do
       before(:each) do
         put :add_to_cart, { :id => 1 } # there are no equipment models in the db so this is invalid
       end
-      it { should redirect_to(root_path) }
-      it { should set_the_flash }
+      it { is_expected.to redirect_to(root_path) }
+      it { is_expected.to set_the_flash }
       it 'should add logger error' do
-        Rails.logger.should_receive(:error).with("Attempt to add invalid equipment model #{1}")
+        expect(Rails.logger).to receive(:error).with("Attempt to add invalid equipment model #{1}")
         put :add_to_cart, { :id => 1 } # this call has to come after the previous line
       end
     end
@@ -66,19 +66,19 @@ describe CatalogController do
         }.to change{session[:cart].items.size}.by(-1)
       end
       it 'should set flash[:error] to the result of Reservation.validate_set if exists' do
-        Reservation.stub(:validate_set).with(session[:cart].reserver, session[:cart].prepare_all).and_return("test")
-        flash[:error].should_not be_nil
+        allow(Reservation).to receive(:validate_set).with(session[:cart].reserver, session[:cart].prepare_all).and_return("test")
+        expect(flash[:error]).not_to be_nil
       end
-      it { should redirect_to(root_path) }
+      it { is_expected.to redirect_to(root_path) }
     end
     context 'invalid equipment_model selected' do
       before(:each) do
         put :remove_from_cart, id: 1
       end
-      it { should redirect_to(root_path) }
-      it { should set_the_flash }
+      it { is_expected.to redirect_to(root_path) }
+      it { is_expected.to set_the_flash }
       it 'should add logger error' do
-        Rails.logger.should_receive(:error).with("Attempt to add invalid equipment model #{1}")
+        expect(Rails.logger).to receive(:error).with("Attempt to add invalid equipment model #{1}")
         put :remove_from_cart, id: 1
       end
     end
@@ -89,15 +89,15 @@ describe CatalogController do
     end
     it 'should set session[:items_per_page] to params[items_per_page] if exists' do
       put :update_user_per_cat_page, :items_per_page => 20
-      session[:items_per_page].should eq('20')
+      expect(session[:items_per_page]).to eq('20')
     end
     it 'should not alter session[:items_per_page] if params[:items_per_page] is nil' do
       session[:items_per_page] = '15'
       put :update_user_per_cat_page, :items_per_page => nil
-      session[:items_per_page].should_not eq(nil)
-      session[:items_per_page].should eq('15')
+      expect(session[:items_per_page]).not_to eq(nil)
+      expect(session[:items_per_page]).to eq('15')
     end
-    it { should redirect_to(root_path) }
+    it { is_expected.to redirect_to(root_path) }
   end
 
   # I don't like that this test is actually searching the database, but unfortunately
@@ -107,7 +107,7 @@ describe CatalogController do
       before(:each) do
         put :search, { query: '' }
       end
-      it { should redirect_to(root_path) }
+      it { is_expected.to redirect_to(root_path) }
     end
     context 'query is not blank' do
       it 'should call catalog_search on EquipmentModel and return active equipment models' do

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe CategoriesController do
+describe CategoriesController, :type => :controller do
   before(:all) do
     @app_config = FactoryGirl.create(:app_config)
   end
   before(:each) do
-    @controller.stub(:first_time_user).and_return(nil)
+    allow(@controller).to receive(:first_time_user).and_return(nil)
     @category = FactoryGirl.create(:category)
   end
   describe 'GET index' do
@@ -14,7 +14,7 @@ describe CategoriesController do
     end
     context 'user is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :index
       end
       it 'should populate an array of all categories if show deleted is true' do
@@ -24,68 +24,68 @@ describe CategoriesController do
       it 'should populate an array of active categories if show deleted is nil or false' do
         expect(assigns(:categories)).to eq([@category])
       end
-      it { should respond_with(:success) }
-      it { should render_template(:index) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:index) }
+      it { is_expected.not_to set_the_flash }
     end
     context 'user is not admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :index
       end
-      it { should redirect_to(root_url) }
-      it { should set_the_flash }
+      it { is_expected.to redirect_to(root_url) }
+      it { is_expected.to set_the_flash }
     end
   end
   describe 'GET show' do
     context 'user is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :show, id: @category
       end
-      it { should respond_with(:success) }
-      it { should render_template(:show) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:show) }
+      it { is_expected.not_to set_the_flash }
       it 'should set @category to the selected category' do
         expect(assigns(:category)).to eq(@category)
       end
     end
     context 'user is not admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :show, id: @category
       end
-      it { should redirect_to(root_url) }
-      it { should set_the_flash }
+      it { is_expected.to redirect_to(root_url) }
+      it { is_expected.to set_the_flash }
     end
   end
   # all methods below should redirect to root_url if user is not an admin
   describe 'GET new' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :new
       end
-      it { should respond_with(:success) }
-      it { should render_template(:new) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:new) }
+      it { is_expected.not_to set_the_flash }
       it 'assigns a new category to @category' do
-        assigns(:category).should be_new_record
-        assigns(:category).kind_of?(Category).should be_truthy
+        expect(assigns(:category)).to be_new_record
+        expect(assigns(:category).kind_of?(Category)).to be_truthy
       end
     end
     context 'not admin' do
       it 'should redirect to root_url' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :new
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'POST create' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
       end
       context 'with valid attributes' do
         before(:each) do
@@ -96,8 +96,8 @@ describe CategoriesController do
             post :create, category: FactoryGirl.attributes_for(:category)
           }.to change(Category,:count).by(1)
         end
-        it { should redirect_to(Category.last) }
-        it { should set_the_flash }
+        it { is_expected.to redirect_to(Category.last) }
+        it { is_expected.to set_the_flash }
       end
       context 'with invalid attributes' do
         before(:each) do
@@ -108,43 +108,43 @@ describe CategoriesController do
             post :create, category: FactoryGirl.attributes_for(:category, name: nil)
           }.not_to change(Category, :count)
         end
-        it { should set_the_flash }
-        it { should render_template(:new) }
+        it { is_expected.to set_the_flash }
+        it { is_expected.to render_template(:new) }
       end
     end
     context 'not admin' do
       it 'should redirect to root url' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         post :create, category: FactoryGirl.attributes_for(:category)
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'GET edit' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :edit, id: @category
       end
       it 'should set @category to the selected category' do
         expect(assigns(:category)).to eq(@category)
       end
-      it { should respond_with(:success) }
-      it { should render_template(:edit) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:edit) }
+      it { is_expected.not_to set_the_flash }
     end
     context 'not admin' do
       it 'should redirect to root_url' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :edit, id: @category
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'PUT update' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
       end
       context 'with valid attributes' do
         before(:each) do
@@ -155,10 +155,10 @@ describe CategoriesController do
         end
         it 'should successfully save new attributes to the database' do
           @category.reload
-          @category.name.should eq("Updated")
+          expect(@category.name).to eq("Updated")
         end
-        it { should redirect_to(@category) }
-        it { should set_the_flash }
+        it { is_expected.to redirect_to(@category) }
+        it { is_expected.to set_the_flash }
       end
       context 'with invalid attributes' do
         before(:each) do
@@ -166,11 +166,11 @@ describe CategoriesController do
         end
         it 'should not update attributes of @category in the database' do
           @category.reload
-          @category.name.should_not be_nil
-          @category.max_per_user.should_not eq(10)
+          expect(@category.name).not_to be_nil
+          expect(@category.max_per_user).not_to eq(10)
         end
-        it { should render_template(:edit) }
-        it { should_not set_the_flash }
+        it { is_expected.to render_template(:edit) }
+        it { is_expected.not_to set_the_flash }
       end
     end
   end

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -1,25 +1,25 @@
 require 'spec_helper'
 
-describe ContactController do
+describe ContactController, :type => :controller do
   before(:all) do
     @app_config = FactoryGirl.create(:app_config)
   end
   before(:each) do
-    @controller.stub(:first_time_user).and_return(nil)
+    allow(@controller).to receive(:first_time_user).and_return(nil)
     @category = FactoryGirl.create(:category)
-    @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+    allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
   end
   describe 'GET new' do
     before(:each) do
       get :new
     end
     it 'should assign @message to a new message' do
-      assigns(:message).should be_new_record
-      assigns(:message).kind_of?(Message).should be_truthy
+      expect(assigns(:message)).to be_new_record
+      expect(assigns(:message).kind_of?(Message)).to be_truthy
     end
-    it { should respond_with(:success) }
-    it { should render_template(:new) }
-    it { should_not set_the_flash }
+    it { is_expected.to respond_with(:success) }
+    it { is_expected.to render_template(:new) }
+    it { is_expected.not_to set_the_flash }
   end
   describe 'POST create' do
     before(:each) do
@@ -30,19 +30,19 @@ describe ContactController do
         post :create, message: FactoryGirl.attributes_for(:message)
       end
       it 'sends a message' do
-        ActionMailer::Base.deliveries.last.subject.should eq('[Reservations Specs] ' + FactoryGirl.build(:message).subject)
+        expect(ActionMailer::Base.deliveries.last.subject).to eq('[Reservations Specs] ' + FactoryGirl.build(:message).subject)
       end
-      it { should redirect_to(root_path) }
-      it { should set_the_flash }
+      it { is_expected.to redirect_to(root_path) }
+      it { is_expected.to set_the_flash }
     end
     context 'with invalid attributes' do
       before(:each) do
         post :create, message: FactoryGirl.attributes_for(:message, name: nil)
       end
-      it { should render_template(:new) }
-      it { should set_the_flash }
+      it { is_expected.to render_template(:new) }
+      it { is_expected.to set_the_flash }
       it 'should not send a message' do
-        ActionMailer::Base.deliveries.should eq([])
+        expect(ActionMailer::Base.deliveries).to eq([])
       end
     end
   end

--- a/spec/controllers/equipment_models_controller_spec.rb
+++ b/spec/controllers/equipment_models_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 shared_examples_for "GET show success" do
-  it { should respond_with(:success) }
-  it { should render_template(:show) }
-  it { should_not set_the_flash }
+  it { is_expected.to respond_with(:success) }
+  it { is_expected.to render_template(:show) }
+  it { is_expected.not_to set_the_flash }
   it 'should set to correct equipment model' do
     expect(assigns(:equipment_model)).to eq(model)
   end
@@ -29,9 +29,9 @@ shared_examples_for "GET show success" do
 end
 
 shared_examples_for "GET index success" do
-it { should respond_with(:success) }
-      it { should render_template(:index) }
-      it { should_not set_the_flash }
+it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:index) }
+      it { is_expected.not_to set_the_flash }
       context 'without show deleted' do
         let!(:mod_other_cat_active) { FactoryGirl.create(:equipment_model) }
         let!(:mod_other_cat_inactive) { FactoryGirl.create(:equipment_model,
@@ -41,18 +41,18 @@ it { should respond_with(:success) }
             mod_same_cat_inactive = FactoryGirl.create(:equipment_model,
               category: model.category, deleted_at: Date.current)
             get :index, category_id: model.category
-            assigns(:equipment_models).include?(model).should be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_active).should_not be_truthy
-            assigns(:equipment_models).include?(mod_same_cat_inactive).should_not be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_inactive).should_not be_truthy
+            expect(assigns(:equipment_models).include?(model)).to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_active)).not_to be_truthy
+            expect(assigns(:equipment_models).include?(mod_same_cat_inactive)).not_to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_inactive)).not_to be_truthy
             expect(assigns(:equipment_models).size).to eq(1)
           end
         end
         context 'without @category set' do
           it 'should populate an array of all active equipment models' do
-            assigns(:equipment_models).include?(model).should be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_active).should be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_inactive).should_not be_truthy
+            expect(assigns(:equipment_models).include?(model)).to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_active)).to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_inactive)).not_to be_truthy
             expect(assigns(:equipment_models).size).to eq(2)
           end
         end
@@ -66,19 +66,19 @@ it { should respond_with(:success) }
             mod_same_cat_inactive = FactoryGirl.create(:equipment_model,
               category: model.category, deleted_at: Date.current)
             get :index, category_id: model.category, show_deleted: true
-            assigns(:equipment_models).include?(model).should be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_active).should_not be_truthy
-            assigns(:equipment_models).include?(mod_same_cat_inactive).should be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_inactive).should_not be_truthy
+            expect(assigns(:equipment_models).include?(model)).to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_active)).not_to be_truthy
+            expect(assigns(:equipment_models).include?(mod_same_cat_inactive)).to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_inactive)).not_to be_truthy
             expect(assigns(:equipment_models).size).to eq(2)
           end
         end
         context 'without @category set' do
           it 'should populate an array of all equipment models' do
             get :index, show_deleted: true
-            assigns(:equipment_models).include?(model).should be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_active).should be_truthy
-            assigns(:equipment_models).include?(mod_other_cat_inactive).should be_truthy
+            expect(assigns(:equipment_models).include?(model)).to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_active)).to be_truthy
+            expect(assigns(:equipment_models).include?(mod_other_cat_inactive)).to be_truthy
             expect(assigns(:equipment_models).size).to eq(3)
           end
         end
@@ -86,21 +86,21 @@ it { should respond_with(:success) }
 
 end
 
-describe EquipmentModelsController do
+describe EquipmentModelsController, :type => :controller do
   before(:all) { @app_config = FactoryGirl.create(:app_config) }
-  before { @controller.stub(:first_time_user).and_return(:nil) }
+  before { allow(@controller).to receive(:first_time_user).and_return(:nil) }
   let!(:model) { FactoryGirl.create(:equipment_model) }
 
   describe 'GET index' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :index
       end
       it_behaves_like "GET index success"
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       describe 'should redirect to root' do
         before { get :index }
         it_behaves_like 'GET index success'
@@ -111,14 +111,14 @@ describe EquipmentModelsController do
   describe 'GET show' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :show, id: model
       end
       it_behaves_like "GET show success"
     end
     context 'with non-admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :show, id: model
       end
       it_behaves_like "GET show success"
@@ -128,18 +128,18 @@ describe EquipmentModelsController do
   describe 'GET new' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :new
       end
-      it { should respond_with(:success) }
-      it { should render_template(:new) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:new) }
+      it { is_expected.not_to set_the_flash }
       it 'assigns a new equipment model to @equipment_model' do
-        assigns(:equipment_model).should be_new_record
-        assigns(:equipment_model).should be_kind_of(EquipmentModel)
+        expect(assigns(:equipment_model)).to be_new_record
+        expect(assigns(:equipment_model)).to be_kind_of(EquipmentModel)
       end
       it 'sets equipment_model to nil when no category is specified' do
-        assigns(:equipment_model).category.should be_nil
+        expect(assigns(:equipment_model).category).to be_nil
       end
       it 'sets category when one is passed through params' do
         cat = model.category
@@ -148,10 +148,10 @@ describe EquipmentModelsController do
       end
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         get :new
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
@@ -159,28 +159,28 @@ describe EquipmentModelsController do
   describe 'GET edit' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :edit, id: model
       end
-      it { should respond_with(:success) }
-      it { should render_template(:edit) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:edit) }
+      it { is_expected.not_to set_the_flash }
       it 'sets @equipment_model to selected model' do
         expect(assigns(:equipment_model)).to eq(model)
       end
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         get :edit, id: model
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
 
   describe 'POST create' do
     context 'with admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:admin)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin)) }
       context 'with valid attributes' do
         before { post :create, equipment_model: FactoryGirl.attributes_for(
           :equipment_model, category_id: model.category) }
@@ -188,65 +188,65 @@ describe EquipmentModelsController do
           expect{ post :create, equipment_model: FactoryGirl.attributes_for(
             :equipment_model, category_id: model.category) }.to change(EquipmentModel, :count).by(1)
         end
-        it { should set_the_flash }
-        it { should redirect_to(EquipmentModel.last) }
+        it { is_expected.to set_the_flash }
+        it { is_expected.to redirect_to(EquipmentModel.last) }
       end
 
       context 'without valid attributes' do
         before { post :create, equipment_model: FactoryGirl.attributes_for(
           :equipment_model, name: nil) }
-        it { should set_the_flash }
-        it { should render_template(:new) }
+        it { is_expected.to set_the_flash }
+        it { is_expected.to render_template(:new) }
         it 'should not save' do
           expect{ post :create, equipment_model: FactoryGirl.attributes_for(
             :equipment_model, name: nil) }.not_to change(EquipmentModel, :count)
         end
-        it { should render_template(:new) }
+        it { is_expected.to render_template(:new) }
       end
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         post :create, equipment_model: FactoryGirl.attributes_for(:equipment_model)
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
 
   describe 'PUT update' do
     context 'with admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:admin)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin)) }
       context 'with valid attributes' do
         before { put :update, id: model, equipment_model:
           FactoryGirl.attributes_for(:equipment_model, name: 'Mod') }
-        it { should set_the_flash }
+        it { is_expected.to set_the_flash }
         it 'sets @equipment_model to selected model' do
           expect(assigns(:equipment_model)).to eq(model)
         end
         it 'updates attributes' do
           model.reload
-          model.name.should == 'Mod'
+          expect(model.name).to eq('Mod')
         end
-        it { should redirect_to(model) }
+        it { is_expected.to redirect_to(model) }
       end
 
       context 'without valid attributes' do
         before { put :update, id: model, equipment_model:
           FactoryGirl.attributes_for(:equipment_model, name: nil) }
-        it { should_not set_the_flash }
+        it { is_expected.not_to set_the_flash }
         it 'should not update attributes' do
           model.reload
-          model.name.should_not be_nil
+          expect(model.name).not_to be_nil
         end
-        it { should render_template(:edit) }
+        it { is_expected.to render_template(:edit) }
       end
       it 'calls delete_files'
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         put :update, id: model, equipment_model: FactoryGirl.attributes_for(:equipment_model)
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end

--- a/spec/controllers/equipment_objects_controller_spec.rb
+++ b/spec/controllers/equipment_objects_controller_spec.rb
@@ -1,20 +1,20 @@
 require 'spec_helper'
 
-describe EquipmentObjectsController do
+describe EquipmentObjectsController, :type => :controller do
   before(:all) { @app_config = FactoryGirl.create(:app_config) }
-  before { @controller.stub(:first_time_user).and_return(:nil) }
+  before { allow(@controller).to receive(:first_time_user).and_return(:nil) }
   let!(:object) { FactoryGirl.create(:equipment_object) }
   let!(:deactivated_object) { FactoryGirl.create(:deactivated) }
 
   describe 'GET index' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :index
       end
-      it { should respond_with(:success) }
-      it { should render_template(:index) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:index) }
+      it { is_expected.not_to set_the_flash }
       context 'without show deleted' do
         let!(:obj_other_cat_active) { FactoryGirl.create(:equipment_object) }
         let!(:obj_other_cat_inactive) { FactoryGirl.create(:equipment_object,
@@ -24,18 +24,18 @@ describe EquipmentObjectsController do
             obj_same_cat_inactive = FactoryGirl.create(:equipment_object,
               equipment_model: object.equipment_model, deleted_at: Date.current)
             get :index, equipment_model_id: object.equipment_model
-            assigns(:equipment_objects).include?(object).should be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_active).should_not be_truthy
-            assigns(:equipment_objects).include?(obj_same_cat_inactive).should_not be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_inactive).should_not be_truthy
+            expect(assigns(:equipment_objects).include?(object)).to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_active)).not_to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_same_cat_inactive)).not_to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_inactive)).not_to be_truthy
             expect(assigns(:equipment_objects).size).to eq(1)
           end
         end
         context 'without @equipment_model set' do
           it 'should populate an array of all active equipment objects' do
-            assigns(:equipment_objects).include?(object).should be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_active).should be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_inactive).should_not be_truthy
+            expect(assigns(:equipment_objects).include?(object)).to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_active)).to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_inactive)).not_to be_truthy
             expect(assigns(:equipment_objects).size).to eq(2)
           end
         end
@@ -49,19 +49,19 @@ describe EquipmentObjectsController do
             obj_same_cat_inactive = FactoryGirl.create(:equipment_object,
               equipment_model: object.equipment_model, deleted_at: Date.current)
             get :index, equipment_model_id: object.equipment_model, show_deleted: true
-            assigns(:equipment_objects).include?(object).should be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_active).should_not be_truthy
-            assigns(:equipment_objects).include?(obj_same_cat_inactive).should be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_inactive).should_not be_truthy
+            expect(assigns(:equipment_objects).include?(object)).to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_active)).not_to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_same_cat_inactive)).to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_inactive)).not_to be_truthy
             expect(assigns(:equipment_objects).size).to eq(2)
           end
         end
         context 'without @equipment_model set' do
           it 'should populate an array of all equipment objects' do
             get :index, show_deleted: true
-            assigns(:equipment_objects).include?(object).should be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_active).should be_truthy
-            assigns(:equipment_objects).include?(obj_other_cat_inactive).should be_truthy
+            expect(assigns(:equipment_objects).include?(object)).to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_active)).to be_truthy
+            expect(assigns(:equipment_objects).include?(obj_other_cat_inactive)).to be_truthy
             expect(assigns(:equipment_objects).size).to eq(4)
           end
         end
@@ -69,17 +69,17 @@ describe EquipmentObjectsController do
     end
     context 'with checkout person user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:checkout_person))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:checkout_person))
         get :index
       end
-      it { should respond_with(:success) }
-      it { should render_template(:index) }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:index) }
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         get :index
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
@@ -87,24 +87,24 @@ describe EquipmentObjectsController do
   describe 'GET show' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :show, id: object
       end
-      it { should respond_with(:success) }
-      it { should render_template(:show) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:show) }
+      it { is_expected.not_to set_the_flash }
       it 'should set to correct equipment object' do
         expect(assigns(:equipment_object)).to eq(object)
       end
     end
     context 'with non-admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :show, id: object
       end
       it 'should redirect to root' do
         get :show, id: object
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
@@ -112,18 +112,18 @@ describe EquipmentObjectsController do
   describe 'GET new' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :new
       end
-      it { should respond_with(:success) }
-      it { should render_template(:new) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:new) }
+      it { is_expected.not_to set_the_flash }
       it 'assigns a new equipment object to @equipment_object' do
-        assigns(:equipment_object).should be_new_record
-        assigns(:equipment_object).should be_kind_of(EquipmentObject)
+        expect(assigns(:equipment_object)).to be_new_record
+        expect(assigns(:equipment_object)).to be_kind_of(EquipmentObject)
       end
       it 'sets equipment_model to nil when no equipment model is specified' do
-        assigns(:equipment_object).equipment_model.should be_nil
+        expect(assigns(:equipment_object).equipment_model).to be_nil
       end
       it 'sets equipment_model when one is passed through params' do
         model = object.equipment_model
@@ -133,19 +133,19 @@ describe EquipmentObjectsController do
     end
     context 'with non-admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :new
       end
       it 'should redirect to root' do
         get :new
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
 
   describe 'POST create' do
     context 'with admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:admin)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin)) }
       context 'with valid attributes' do
         before { post :create, equipment_object: FactoryGirl.attributes_for(:equipment_object,
           serial: "Enter serial # (optional)", equipment_model_id: object.equipment_model.id) }
@@ -154,26 +154,26 @@ describe EquipmentObjectsController do
             :equipment_object, equipment_model_id: object.equipment_model.id)
             }.to change(EquipmentObject, :count).by(1)
         end
-        it { should set_the_flash }
-        it { should redirect_to(EquipmentObject.last.equipment_model) }
+        it { is_expected.to set_the_flash }
+        it { is_expected.to redirect_to(EquipmentObject.last.equipment_model) }
       end
       context 'without valid attributes' do
         before { post :create, equipment_object: FactoryGirl.attributes_for(
           :equipment_object, name: nil) }
-        it { should_not set_the_flash }
-        it { should render_template(:new) }
+        it { is_expected.not_to set_the_flash }
+        it { is_expected.to render_template(:new) }
         it 'should not save' do
           expect{ post :create, equipment_object: FactoryGirl.attributes_for(
             :equipment_object, name: nil) }.not_to change(EquipmentObject, :count)
         end
-        it { should render_template(:new) }
+        it { is_expected.to render_template(:new) }
       end
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         post :create, equipment_object: FactoryGirl.attributes_for(:equipment_object)
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
@@ -181,57 +181,57 @@ describe EquipmentObjectsController do
   describe 'GET edit' do
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :edit, id: object
       end
-      it { should respond_with(:success) }
-      it { should render_template(:edit) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:edit) }
+      it { is_expected.not_to set_the_flash }
       it 'sets @equipment_object to selected object' do
         expect(assigns(:equipment_object)).to eq(object)
       end
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         get :edit, id: object
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
 
   describe 'PUT update' do
     context 'with admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:admin)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin)) }
       context 'with valid attributes' do
         before { put :update, id: object,
           equipment_object: FactoryGirl.attributes_for(:equipment_object, name: 'Obj') }
-        it { should set_the_flash }
+        it { is_expected.to set_the_flash }
         it 'sets @equipment_object to selected object' do
           expect(assigns(:equipment_object)).to eq(object)
         end
         it 'updates attributes' do
           object.reload
-          object.name.should == 'Obj'
+          expect(object.name).to eq('Obj')
         end
-        it { should redirect_to(object.equipment_model) }
+        it { is_expected.to redirect_to(object.equipment_model) }
       end
       context 'without valid attributes' do
         before { put :update, id: object,
           equipment_object: FactoryGirl.attributes_for(:equipment_object, name: nil) }
-        it { should_not set_the_flash }
+        it { is_expected.not_to set_the_flash }
         it 'should not update attributes' do
           object.reload
-          object.name.should_not be_nil
+          expect(object.name).not_to be_nil
         end
-        it { should render_template(:edit) }
+        it { is_expected.to render_template(:edit) }
       end
     end
     context 'with non-admin user' do
-      before { @controller.stub(:current_user).and_return(FactoryGirl.create(:user)) }
+      before { allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user)) }
       it 'should redirect to root' do
         put :update, id: object, equipment_object: FactoryGirl.attributes_for(:equipment_object)
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
@@ -240,11 +240,11 @@ describe EquipmentObjectsController do
     before { request.env['HTTP_REFERER'] = '/referrer' }
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         put :deactivate, id: object, deactivation_reason: "Because I can"
         object.reload
       end
-      it { response.should be_redirect }
+      it { expect(response).to be_redirect }
 
       subject { object }
       its(:deactivation_reason) { should == "Because I can" }
@@ -252,11 +252,11 @@ describe EquipmentObjectsController do
 
     context 'with non-admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
       end
       it 'should redirect to root' do
         put :deactivate, id: object, deactivation_reason: "Because I can't"
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
@@ -265,12 +265,12 @@ describe EquipmentObjectsController do
     before { request.env['HTTP_REFERER'] = '/referrer' }
     context 'with admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         put :activate, id: deactivated_object
         deactivated_object.reload
       end
 
-      it { response.should be_redirect }
+      it { expect(response).to be_redirect }
 
       subject { deactivated_object }
       its(:deactivation_reason) { should == nil }
@@ -278,12 +278,12 @@ describe EquipmentObjectsController do
 
     context 'with non-admin user' do
       before do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
       end
 
       it 'should redirect to root' do
         put :activate, id: object
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end

--- a/spec/controllers/log_controller_spec.rb
+++ b/spec/controllers/log_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe LogController, versioning: true do
+describe LogController, type: :controller, versioning: true do
   render_views
 
   before(:all) do
@@ -8,8 +8,8 @@ describe LogController, versioning: true do
   end
   before(:each) do
     PaperTrail.enabled = true
-    @controller.stub(:first_time_user).and_return(FactoryGirl.create(:user))
-    @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+    allow(@controller).to receive(:first_time_user).and_return(FactoryGirl.create(:user))
+    allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
     PaperTrail.whodunnit = @controller.current_user
       # Necessary because for some reason, user ID that is responsible for
       # changes is deleted between tests
@@ -23,7 +23,7 @@ describe LogController, versioning: true do
   describe "GET 'index'" do
     it "returns http success" do
       get 'index'
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "contains links to all individual-version views, regardless of object type" do
@@ -38,24 +38,24 @@ describe LogController, versioning: true do
 
     it "returns http success if :id exists" do
       get 'version', id: @reservation.versions.first.id
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "redirects to index if :id doesn't exist" do
       get 'version', id: 0
-      response.should redirect_to('/log/index')
+      expect(response).to redirect_to('/log/index')
     end
   end
 
   describe "GET 'history/:object_type/:id'" do
     it "returns http success if Reservation :id exists" do
       get 'history', id: @reservation.id, object_type: :reservation
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "redirects to index if Reservation :id doesn't exist" do
       get 'history', id: 0, object_type: :reservation
-      response.should be_redirect
+      expect(response).to be_redirect
     end
   end
 end

--- a/spec/controllers/requirements_controller_spec.rb
+++ b/spec/controllers/requirements_controller_spec.rb
@@ -2,103 +2,103 @@ require 'spec_helper'
 
 # note, these tests are complex in order to test the admin security features -- namely, it was necessary
 # to test two contexts for each method: the user being an admin, and not.
-describe RequirementsController do
+describe RequirementsController, :type => :controller do
   before(:all) do
     @app_config = FactoryGirl.create(:app_config)
   end
   before(:each) do
-    @controller.stub(:first_time_user).and_return(nil) # required stub or every test will fail
+    allow(@controller).to receive(:first_time_user).and_return(nil) # required stub or every test will fail
     @requirement = FactoryGirl.create(:requirement, contact_name: "Adam Bray")
   end
   describe 'GET index' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :index
       end
-      it { should respond_with(:success) }
-      it { should render_template(:index) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:index) }
+      it { is_expected.not_to set_the_flash }
       it 'should populate an array of all requirements' do
         expect(assigns(:requirements)).to eq([@requirement])
       end
     end
     context 'not an admin' do
       it 'should redirect to root url if not an admin' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :index
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'GET show' do
     context 'is an admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :show, id: @requirement
       end
-      it { should respond_with(:success) }
-      it { should render_template(:show) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:show) }
+      it { is_expected.not_to set_the_flash }
       it 'should set @requirement to the selected requirement' do
         expect(assigns(:requirement)).to eq(@requirement)
       end
     end
     context 'not an admin' do
       it 'should redirect to root url if not an admin' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :show, id: @requirement
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'GET new' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :new
       end
-      it { should respond_with(:success) }
-      it { should render_template(:new) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:new) }
+      it { is_expected.not_to set_the_flash }
       it 'assigns a new requirement to @requirement' do
-        assigns(:requirement).should be_new_record
-        assigns(:requirement).kind_of?(Requirement).should be_truthy
+        expect(assigns(:requirement)).to be_new_record
+        expect(assigns(:requirement).kind_of?(Requirement)).to be_truthy
       end
     end
     context 'not an admin' do
       it 'should redirect to root url if not an admin' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :new
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'GET edit' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
         get :edit, id: @requirement
       end
       it 'should set @requirement to the selected requirement' do
         expect(assigns(:requirement)).to eq(@requirement)
       end
-      it { should respond_with(:success) }
-      it { should render_template(:edit) }
-      it { should_not set_the_flash }
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template(:edit) }
+      it { is_expected.not_to set_the_flash }
     end
     context 'not admin' do
       it 'should redirect to root url if not an admin' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :edit, id: @requirement
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'PUT update' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
       end
       context 'with valid attributes' do
         before(:each) do
@@ -109,10 +109,10 @@ describe RequirementsController do
         end
         it 'should update the attributes of @requirement' do
           @requirement.reload
-          @requirement.contact_name.should == "John Doe"
+          expect(@requirement.contact_name).to eq("John Doe")
         end
-        it { should redirect_to(@requirement) }
-        it { should set_the_flash }
+        it { is_expected.to redirect_to(@requirement) }
+        it { is_expected.to set_the_flash }
       end
       context 'with invalid attributes' do
         before(:each) do
@@ -120,25 +120,25 @@ describe RequirementsController do
         end
         it 'should not update the attributes of @requirement' do
           @requirement.reload
-          @requirement.contact_name.should_not == ""
-          @requirement.contact_name.should == "Adam Bray"
+          expect(@requirement.contact_name).not_to eq("")
+          expect(@requirement.contact_name).to eq("Adam Bray")
         end
-        it { should render_template(:edit) }
-        it { should_not set_the_flash }
+        it { is_expected.to render_template(:edit) }
+        it { is_expected.not_to set_the_flash }
       end
     end
     context 'not admin' do
       it 'should redirect to root url if not an admin' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         get :update, id: @requirement, requirement: FactoryGirl.attributes_for(:requirement)
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'POST create' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
       end
       context 'with valid attributes' do
         before(:each) do
@@ -149,8 +149,8 @@ describe RequirementsController do
             post :create, requirement: FactoryGirl.attributes_for(:requirement)
           }.to change(Requirement,:count).by(1)
         end
-        it { should redirect_to(Requirement.last) }
-        it { should set_the_flash }
+        it { is_expected.to redirect_to(Requirement.last) }
+        it { is_expected.to set_the_flash }
       end
       context 'with invalid attributes' do
         before(:each) do
@@ -161,22 +161,22 @@ describe RequirementsController do
             post :create, requirement: FactoryGirl.attributes_for(:requirement, contact_name: nil)
           }.not_to change(Requirement,:count)
         end
-        it { should_not set_the_flash }
-        it { should render_template(:new) }
+        it { is_expected.not_to set_the_flash }
+        it { is_expected.to render_template(:new) }
       end
     end
     context 'not admin' do
       it 'should redirect to root url if not an admin' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         post :create, requirement: FactoryGirl.attributes_for(:requirement)
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end
   describe 'DELETE destroy' do
     context 'is admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
       end
       it 'assigns the selected requirement to @requirement' do
         delete :destroy, id: @requirement
@@ -189,14 +189,14 @@ describe RequirementsController do
       end
       it 'should redirect to the requirements index page' do
         delete :destroy, id: @requirement
-        response.should redirect_to requirements_url
+        expect(response).to redirect_to requirements_url
       end
     end
     context 'not admin' do
       it 'should redirect to root url if not an admin' do
-        @controller.stub(:current_user).and_return(FactoryGirl.create(:user))
+        allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:user))
         delete :destroy, id: @requirement
-        response.should redirect_to(root_url)
+        expect(response).to redirect_to(root_url)
       end
     end
   end

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ReservationsController do
+describe ReservationsController, :type => :controller do
 
   ## Common setup
   render_views
@@ -26,26 +26,26 @@ describe ReservationsController do
   before(:each) do
     @cart = FactoryGirl.build(:cart, reserver_id: @user.id)
 
-    @controller.stub(:first_time_user).and_return(nil)
-    @controller.stub(:current_user).and_return(@user)
+    allow(@controller).to receive(:first_time_user).and_return(nil)
+    allow(@controller).to receive(:current_user).and_return(@user)
 
     @reservation = FactoryGirl.create(:valid_reservation, reserver: @user)
   end
 
   ## Shared examples
   shared_examples 'cannot access page' do
-    it { response.should be_redirect }
-    it { should set_the_flash }
+    it { expect(response).to be_redirect }
+    it { is_expected.to set_the_flash }
   end
 
   shared_examples 'inaccessible by banned user' do
     before(:each) do
       banned = FactoryGirl.build(:banned)
-      @controller.stub(:current_user).and_return(banned)
-      Reservation.stub(:find).and_return(FactoryGirl.build_stubbed(:reservation, reserver: banned))
+      allow(@controller).to receive(:current_user).and_return(banned)
+      allow(Reservation).to receive(:find).and_return(FactoryGirl.build_stubbed(:reservation, reserver: banned))
     end
     include_examples 'cannot access page'
-    it { should redirect_to(root_path) }
+    it { is_expected.to redirect_to(root_path) }
   end
 
   ## Controller method tests
@@ -61,8 +61,8 @@ describe ReservationsController do
 
     context 'when accessed by non-banned user' do
       subject { get :index }
-      it { should be_success }
-      it { should render_template(:index) }
+      it { is_expected.to be_success }
+      it { is_expected.to render_template(:index) }
 
       it 'populates @reservations_set with respect to params[filter]' do
         # Setup
@@ -96,7 +96,7 @@ describe ReservationsController do
 
       context 'who is an admin' do
         before(:each) do
-          @controller.stub(:current_user).and_return(@admin)
+          allow(@controller).to receive(:current_user).and_return(@admin)
           @filters.each do |trait|
             res = FactoryGirl.build(:valid_reservation, trait,
                                     reserver: [@user, @admin].sample)
@@ -111,7 +111,7 @@ describe ReservationsController do
 
       context 'who is not an admin' do
         before(:each) do
-          @controller.stub(:current_user).and_return(@user)
+          allow(@controller).to receive(:current_user).and_return(@user)
           @filters.each do |trait|
             res = FactoryGirl.build(:valid_reservation, trait,
                                     reserver: [@user,@admin].sample)
@@ -138,15 +138,15 @@ describe ReservationsController do
 
     shared_examples 'can view reservation by patron' do
       before(:each) { get :show, id: @reservation.id }
-      it { should render_template(:show) }
-      it { response.should be_success }
+      it { is_expected.to render_template(:show) }
+      it { expect(response).to be_success }
       it { expect(assigns(:reservation)).to eq @reservation }
     end
 
     shared_examples 'can view reservation by admin' do
       before(:each) { get :show, id: @admin_res.id }
-      it { should render_template(:show) }
-      it { response.should be_success }
+      it { is_expected.to render_template(:show) }
+      it { expect(response).to be_success }
       it { expect(assigns(:reservation)).to eq @admin_res }
     end
 
@@ -157,7 +157,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
       end
 
       it_behaves_like 'can view reservation by patron'
@@ -166,7 +166,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
       end
 
       it_behaves_like 'can view reservation by patron'
@@ -175,7 +175,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
       end
 
       it_behaves_like 'can view reservation by patron'
@@ -194,14 +194,14 @@ describe ReservationsController do
     end
 
     context 'when accessed by a non-banned user' do
-      before(:each) { @controller.stub(:current_user).and_return(@user) }
+      before(:each) { allow(@controller).to receive(:current_user).and_return(@user) }
 
       context 'with an empty cart' do
         before(:each) do
           get :new
         end
-        it { response.should be_redirect }
-        it { should set_the_flash }
+        it { expect(response).to be_redirect }
+        it { is_expected.to set_the_flash }
       end
 
       context 'with a non-empty cart' do
@@ -211,7 +211,7 @@ describe ReservationsController do
         end
 
         it 'should display errors'
-        it { should render_template(:new) }
+        it { is_expected.to render_template(:new) }
       end
     end
   end
@@ -222,7 +222,7 @@ describe ReservationsController do
     end
 
     context 'when accessed by non-banned user' do
-      before(:each) { @controller.stub(:current_user).and_return(@user) }
+      before(:each) { allow(@controller).to receive(:current_user).and_return(@user) }
 
       context 'with validation-failing items in Cart' do
         before(:each) do
@@ -241,11 +241,11 @@ describe ReservationsController do
 
         context 'no justification provided' do
           before do
-            @controller.stub(:current_user).and_return(@checkout_person)
+            allow(@controller).to receive(:current_user).and_return(@checkout_person)
             @req_no_notes.call
           end
 
-          it { should render_template(:new) }
+          it { is_expected.to render_template(:new) }
 
           it 'should set @notes_required to true' do
             expect(assigns(:notes_required)).to be_truthy
@@ -256,7 +256,7 @@ describe ReservationsController do
         context 'and user can override errors' do
           before(:each) do
             AppConfig.first.update_attributes(override_on_create: true)
-            @controller.stub(:current_user).and_return(@checkout_person)
+            allow(@controller).to receive(:current_user).and_return(@checkout_person)
           end
 
           it 'affects the database' do
@@ -265,12 +265,12 @@ describe ReservationsController do
 
           it 'should redirect' do
             @req.call
-            response.should redirect_to(manage_reservations_for_user_path(@user.id))
+            expect(response).to redirect_to(manage_reservations_for_user_path(@user.id))
           end
 
           it 'sets the flash' do
             @req.call
-            flash[:notice].should_not be_nil
+            expect(flash[:notice]).not_to be_nil
           end
         end
 
@@ -278,18 +278,18 @@ describe ReservationsController do
           # request would be filed
           before(:each) do
             AppConfig.first.update_attributes(override_on_create: false)
-            @controller.stub(:current_user).and_return(@checkout_person)
+            allow(@controller).to receive(:current_user).and_return(@checkout_person)
           end
           it 'affects database' do
             expect { @req.call }.to change { Reservation.count }
           end
           it 'redirects to catalog_path' do
             @req.call
-            response.should redirect_to(catalog_path)
+            expect(response).to redirect_to(catalog_path)
           end
           it 'should not set the flash' do
             @req.call
-            flash[:error].should be_nil
+            expect(flash[:error]).to be_nil
           end
         end
       end
@@ -310,16 +310,16 @@ describe ReservationsController do
         end
         it 'empties the Cart' do
           @req.call
-          response.request.env['rack.session'][:cart].items.count.should eq(0)
+          expect(response.request.env['rack.session'][:cart].items.count).to eq(0)
           # Cart.should_receive(:new)
         end
         it 'sets flash[:notice]' do
           @req.call
-          flash[:notice].should_not be_nil
+          expect(flash[:notice]).not_to be_nil
         end
         it 'is a redirect' do
           @req.call
-          response.should be_redirect
+          expect(response).to be_redirect
         end
       end
     end
@@ -333,7 +333,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
         get 'edit', id: @reservation.id
       end
       include_examples 'cannot access page'
@@ -341,7 +341,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person disallowed by settings' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
         AppConfig.first.update_attributes(checkout_persons_can_edit: false)
         get 'edit', id: @reservation.id
       end
@@ -359,12 +359,12 @@ describe ReservationsController do
       it 'assigns @option_array with the correct contents' do
         expect(assigns(:option_array)).to eq @reservation.equipment_model.equipment_objects.collect { |e| [e.name, e.id] }
       end
-      it { should render_template(:edit) }
+      it { is_expected.to render_template(:edit) }
     end
 
     context 'when accessed by checkout person allowed by settings' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
         AppConfig.first.update_attributes(checkout_persons_can_edit: true)
         get :edit, id: @reservation.id
       end
@@ -373,7 +373,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
         AppConfig.first.update_attributes(checkout_persons_can_edit: false)
         get :edit, id: @reservation.id
       end
@@ -401,7 +401,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
         put 'update', id: @reservation.id
       end
       include_examples 'cannot access page'
@@ -409,7 +409,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person disallowed by settings' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
         AppConfig.first.update_attributes(checkout_persons_can_edit: false)
         put 'update', id: @reservation.id, reservation: FactoryGirl.attributes_for(:reservation)
       end
@@ -432,7 +432,7 @@ describe ReservationsController do
           expect(@reservation.start_date.to_time.utc).to eq(Time.current.midnight.utc)
           expect(@reservation.due_date.to_time.utc).to eq((Time.current.midnight + 4*24.hours).utc)
         end
-        it { should redirect_to(@reservation) }
+        it { is_expected.to redirect_to(@reservation) }
       end
 
       describe 'and provides valid params[:equipment_object]' do
@@ -447,7 +447,7 @@ describe ReservationsController do
         it 'should update the object on current reservation' do
           expect{ @reservation.reload }.to change{@reservation.equipment_object}
         end
-        it { should redirect_to(@reservation) }
+        it { is_expected.to redirect_to(@reservation) }
       end
 
       # Unhappy path
@@ -466,7 +466,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person allowed by settings' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
         AppConfig.first.update_attributes(checkout_persons_can_edit: true)
       end
       include_examples 'can access update page'
@@ -474,7 +474,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
         AppConfig.first.update_attributes(checkout_persons_can_edit: false)
       end
       include_examples 'can access update page'
@@ -496,12 +496,12 @@ describe ReservationsController do
 
       it 'redirects to reservations_url' do
         delete :destroy, id: reservation.id
-        response.should redirect_to(reservations_url)
+        expect(response).to redirect_to(reservations_url)
       end
 
       it 'sets the flash' do
         delete :destroy, id: reservation.id
-        flash[:notice].should_not be_nil
+        expect(flash[:notice]).not_to be_nil
       end
     end
 
@@ -513,7 +513,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
       end
 
       include_examples 'can destroy reservation' do
@@ -523,7 +523,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
       end
 
       context 'and the reservation is checked out' do
@@ -541,7 +541,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
       end
 
       context 'and the reservation is their own' do
@@ -579,8 +579,8 @@ describe ReservationsController do
 
     shared_examples 'can access #manage' do
       before(:each) { get :manage, user_id: @user.id }
-      it { response.should be_success }
-      it { should render_template(:manage) }
+      it { expect(response).to be_success }
+      it { is_expected.to render_template(:manage) }
 
       it 'assigns @user correctly' do
         expect(assigns(:user)).to eq(@user)
@@ -597,7 +597,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
       end
 
       include_examples 'can access #manage'
@@ -605,7 +605,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
       end
 
       include_examples 'can access #manage'
@@ -613,7 +613,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
         get :manage, user_id: @user.id
       end
 
@@ -636,8 +636,8 @@ describe ReservationsController do
 
     shared_examples 'can access #current' do
       before { get :current, user_id: @user.id }
-      it { response.should be_success }
-      it { should render_template(:current_reservations) }
+      it { expect(response).to be_success }
+      it { is_expected.to render_template(:current_reservations) }
 
       it 'assigns @user correctly' do
         expect(assigns(:user)).to eq(@user)
@@ -662,7 +662,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
       end
 
       include_examples 'can access #current'
@@ -670,7 +670,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
       end
 
       include_examples 'can access #current'
@@ -678,7 +678,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
         get :current, user_id: @user.id
       end
 
@@ -715,8 +715,8 @@ describe ReservationsController do
         put :checkout, user_id: @user.id, reservations: reservations_params
       end
 
-      it { response.should be_success }
-      it { should render_template(:receipt) }
+      it { expect(response).to be_success }
+      it { is_expected.to render_template(:receipt) }
 
       it 'assigns empty @check_in_set' do
         expect(assigns(:check_in_set)).to be_empty
@@ -739,7 +739,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
       end
 
       include_examples 'has successful checkout'
@@ -747,7 +747,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
       end
 
       include_examples 'has successful checkout'
@@ -755,7 +755,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
         put :checkout, user_id: @user.id
       end
 
@@ -768,24 +768,24 @@ describe ReservationsController do
 
     context 'when tos returns false' do
       before do
-        @controller.stub(:check_tos).and_return(false)
+        allow(@controller).to receive(:check_tos).and_return(false)
         put :checkout
       end
-      it { response.should be_redirect }
+      it { expect(response).to be_redirect }
     end
 
     context 'when not all procedures are filled out' do
       before do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
         @obj = FactoryGirl.create(:equipment_object, equipment_model: @reservation.equipment_model)
         @procedure = FactoryGirl.create(:checkout_procedure, equipment_model: @reservation.equipment_model)
         reservations_params = {@reservation.id.to_s => {notes: "", equipment_object_id: @obj.id, checkout_procedures: {}}}
         put :checkout, user_id: @user.id,  reservations: reservations_params
       end
 
-      it { response.should be_success }
+      it { expect(response).to be_success }
 
-      it { should render_template(:receipt) }
+      it { is_expected.to render_template(:receipt) }
 
       it 'assigns empty @check_in_set' do
         expect(assigns(:check_in_set)).to be_empty
@@ -812,35 +812,35 @@ describe ReservationsController do
         reservations_params = {}
         put :checkout, user_id: @user.id, reservations: reservations_params
       end
-      it { should set_the_flash }
-      it { response.should be_redirect }
+      it { is_expected.to set_the_flash }
+      it { expect(response).to be_redirect }
     end
 
     context 'reserver has overdue reservations' do
 
       context 'can override reservations?' do
         before do
-          @controller.stub(:current_user).and_return(@admin)
+          allow(@controller).to receive(:current_user).and_return(@admin)
           @obj = FactoryGirl.create(:equipment_object, equipment_model: @reservation.equipment_model)
           reservations_params = {@reservation.id.to_s => {notes: "", equipment_object_id: @obj.id }}
           overdue = FactoryGirl.build(:overdue_reservation, reserver_id: @user.id)
           overdue.save(validate: false)
           put :checkout, user_id: @user.id, reservations: reservations_params
         end
-        it { response.should be_success }
-        it { should render_template(:receipt) }
+        it { expect(response).to be_success }
+        it { is_expected.to render_template(:receipt) }
       end
       context 'cannot override' do
         before do
-          @controller.stub(:current_user).and_return(@user)
+          allow(@controller).to receive(:current_user).and_return(@user)
           @obj = FactoryGirl.create(:equipment_object, equipment_model: @reservation.equipment_model)
           reservations_params = {@reservation.id.to_s => {notes: "", equipment_object_id: @obj.id }}
           overdue = FactoryGirl.build(:overdue_reservation, reserver_id: @user.id)
           overdue.save(validate: false)
           put :checkout, user_id: @user.id, reservations: reservations_params
         end
-        it { should set_the_flash }
-        it { response.should be_redirect }
+        it { is_expected.to set_the_flash }
+        it { expect(response).to be_redirect }
       end
 
     end
@@ -865,8 +865,8 @@ describe ReservationsController do
         put :checkin, user_id: @user.id, reservations: reservations_params
       end
 
-      it { response.should be_success }
-      it { should render_template(:receipt) }
+      it { expect(response).to be_success }
+      it { is_expected.to render_template(:receipt) }
 
       it 'assigns empty @check_out_set' do
         expect(assigns(:check_out_set)).to be_empty
@@ -887,7 +887,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
       end
 
       include_examples 'has successful checkin'
@@ -895,7 +895,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
       end
 
       include_examples 'has successful checkin'
@@ -903,7 +903,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
         put :checkin, user_id: @user.id
       end
 
@@ -916,7 +916,7 @@ describe ReservationsController do
 
     context 'items have already been checked in' do
       before do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
         request.env["HTTP_REFERER"] = 'where_i_came_from'
         @reservation = FactoryGirl.build(:checked_in_reservation, reserver: @user)
         @reservation.save(validate: false)
@@ -924,31 +924,31 @@ describe ReservationsController do
         put :checkin, user_id: @user.id, reservations: reservations_params
       end
 
-      it { should set_the_flash }
-      it { response.should be_redirect }
+      it { is_expected.to set_the_flash }
+      it { expect(response).to be_redirect }
     end
 
     context 'no reservations to check in' do
       before do
         request.env["HTTP_REFERER"] = 'where_i_came_from'
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
         put :checkin,  user_id: @user.id, reservations: {}
       end
-      it { should set_the_flash }
-      it { response.should be_redirect }
+      it { is_expected.to set_the_flash }
+      it { expect(response).to be_redirect }
     end
 
     context 'when not all procedures are filled out' do
       before do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
         @reservation = FactoryGirl.create(:checked_out_reservation, reserver: @user)
         @procedure = FactoryGirl.create(:checkin_procedure, equipment_model: @reservation.equipment_model)
         reservations_params = {@reservation.id.to_s => {notes: "", checkin?: "1", checkin_procedures: {}}}
         put :checkin, user_id: @user.id, reservations: reservations_params
       end
 
-      it { response.should be_success }
-      it { should render_template(:receipt) }
+      it { expect(response).to be_success }
+      it { is_expected.to render_template(:receipt) }
 
       it 'assigns empty @check_out_set' do
         expect(assigns(:check_out_set)).to be_empty
@@ -988,7 +988,7 @@ describe ReservationsController do
         put :renew, id: @reservation.id
       end
 
-      it { should redirect_to(root_path) }
+      it { is_expected.to redirect_to(root_path) }
 
       it 'should extend due_date' do
         expect { @reservation.reload }.to change { @reservation.due_date }
@@ -997,7 +997,7 @@ describe ReservationsController do
 
     context 'when accessed by admin' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@admin)
+        allow(@controller).to receive(:current_user).and_return(@admin)
       end
 
       include_examples 'can renew reservation'
@@ -1005,7 +1005,7 @@ describe ReservationsController do
 
     context 'when accessed by checkout person' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@checkout_person)
+        allow(@controller).to receive(:current_user).and_return(@checkout_person)
       end
 
       include_examples 'can renew reservation'
@@ -1013,7 +1013,7 @@ describe ReservationsController do
 
     context 'when accessed by patron' do
       before(:each) do
-        @controller.stub(:current_user).and_return(@user)
+        allow(@controller).to receive(:current_user).and_return(@user)
       end
 
       include_examples 'can renew reservation'
@@ -1023,7 +1023,7 @@ describe ReservationsController do
           @other_res = FactoryGirl.create(:checked_out_reservation)
           put :renew, id: @other_res.id
         end
-        it { response.should be_redirect }
+        it { expect(response).to be_redirect }
       end
 
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,51 +1,51 @@
 require 'spec_helper'
 
 shared_examples_for 'page success' do
-  it { should respond_with(:success) }
-  it { should_not set_the_flash }
+  it { is_expected.to respond_with(:success) }
+  it { is_expected.not_to set_the_flash }
 end
 
 shared_examples_for 'access denied' do
-  it { should redirect_to(root_url) }
-  it { should set_the_flash }
+  it { is_expected.to redirect_to(root_url) }
+  it { is_expected.to set_the_flash }
 end
 
-describe UsersController do
+describe UsersController, :type => :controller do
   before(:all) {
     @app_config = FactoryGirl.create(:app_config)
   }
   before {
-    @controller.stub(:first_time_user).and_return(:nil)
+    allow(@controller).to receive(:first_time_user).and_return(:nil)
   }
   let!(:user) { FactoryGirl.create(:user) }
 
   context 'with admin user' do
     before do
-      @controller.stub(:current_user).and_return(FactoryGirl.create(:admin))
+      allow(@controller).to receive(:current_user).and_return(FactoryGirl.create(:admin))
     end
     describe 'GET index' do
       let!(:banned) { FactoryGirl.create(:banned) }
       let!(:other_user) { FactoryGirl.create(:user) }
       before { get :index }
       it_behaves_like "page success"
-      it { should render_template(:index) }
+      it { is_expected.to render_template(:index) }
       context 'without show banned' do
         it 'should assign users to all active users' do
-          assigns(:users).include?(other_user).should be_truthy
-          assigns(:users).include?(banned).should be_falsey
+          expect(assigns(:users).include?(other_user)).to be_truthy
+          expect(assigns(:users).include?(banned)).to be_falsey
         end
       end
       context 'with show banned' do
         before { get :index, show_banned: true }
         it 'should assign users to all users' do
-          assigns(:users).include?(banned).should be_truthy
+          expect(assigns(:users).include?(banned)).to be_truthy
         end
       end
     end
     describe 'GET show' do
       before { get :show, id: user }
       it_behaves_like "page success"
-      it { should render_template(:show) }
+      it { is_expected.to render_template(:show) }
     end
 
     describe 'POST quick_new' do
@@ -68,7 +68,7 @@ describe UsersController do
         expect(assigns(:can_edit_login)).to be_truthy
       end
       it_behaves_like 'page success'
-      it { should render_template(:new) }
+      it { is_expected.to render_template(:new) }
     end
     describe 'POST create' do
       context 'with correct params' do
@@ -77,7 +77,7 @@ describe UsersController do
           post :create, user: @user_attributes
         end
         it 'should save the user' do
-          User.find(assigns(:user)).should_not be_nil
+          expect(User.find(assigns(:user))).not_to be_nil
         end
       end
       context 'with incorrect params' do
@@ -97,7 +97,7 @@ describe UsersController do
         expect(assigns(:can_edit_login)).to be_truthy
       end
       it_behaves_like 'page success'
-      it { should render_template(:edit) }
+      it { is_expected.to render_template(:edit) }
     end
     describe 'PUT update' do
       context 'with nice params' do
@@ -106,9 +106,9 @@ describe UsersController do
           put :update, user: @new_attributes, id: user
         end
         it 'should update the user' do
-          User.find(user)[:first_name].should eq("Lolita")
+          expect(User.find(user)[:first_name]).to eq("Lolita")
         end
-        it { should set_the_flash }
+        it { is_expected.to set_the_flash }
       end
       context 'without nice params' do
         before do
@@ -116,7 +116,7 @@ describe UsersController do
           put :update, user: @bad_attributes, id: user
         end
         it 'should not save' do
-          User.find(user)[:first_name].should_not eq("Lolita")
+          expect(User.find(user)[:first_name]).not_to eq("Lolita")
         end
       end
     end
@@ -126,8 +126,8 @@ describe UsersController do
           request.env["HTTP_REFERER"] = "where_i_came_from"
           put :find, fake_searched_id: ""
         end
-        it { should set_the_flash }
-        it { should redirect_to("where_i_came_from") }
+        it { is_expected.to set_the_flash }
+        it { is_expected.to redirect_to("where_i_came_from") }
       end
       context 'searched id is blank' do
         context 'valid id' do
@@ -138,15 +138,15 @@ describe UsersController do
           it 'should assign user correctly' do
             expect(assigns(:user)).to eq(User.where(login: 'csw3').first)
           end
-          it { should redirect_to(manage_reservations_for_user_path(assigns(:user))) }
+          it { is_expected.to redirect_to(manage_reservations_for_user_path(assigns(:user))) }
         end
         context 'invalid id' do
           before do
             request.env["HTTP_REFERER"] = "where_i_came_from"
             put :find, fake_searched_id: "not_a_real_id3", searched_id: ""
           end
-          it { should set_the_flash }
-          it { should redirect_to("where_i_came_from") }
+          it { is_expected.to set_the_flash }
+          it { is_expected.to redirect_to("where_i_came_from") }
         end
       end
       context 'searched id is not blank' do
@@ -156,7 +156,7 @@ describe UsersController do
         it 'should assign user' do
           expect(assigns(:user)).to eq(user)
         end
-        it { should redirect_to(manage_reservations_for_user_path(assigns(:user)))}
+        it { is_expected.to redirect_to(manage_reservations_for_user_path(assigns(:user)))}
 
 
       end
@@ -172,8 +172,8 @@ describe UsersController do
         expect(@user.role).to eq('banned')
         expect(@user.view_mode).to eq('banned')
       end
-      it { should set_the_flash }
-      it { should redirect_to("where_i_came_from") }
+      it { is_expected.to set_the_flash }
+      it { is_expected.to redirect_to("where_i_came_from") }
     end
     describe 'PUT unban' do
       before do
@@ -188,8 +188,8 @@ describe UsersController do
         expect(@user.view_mode).to eq('normal')
       end
 
-      it { should set_the_flash}
-      it { should redirect_to("where_i_came_from") }
+      it { is_expected.to set_the_flash}
+      it { is_expected.to redirect_to("where_i_came_from") }
     end
 
 

--- a/spec/helpers/announcements_helper_spec.rb
+++ b/spec/helpers/announcements_helper_spec.rb
@@ -10,6 +10,6 @@ require 'spec_helper'
 #     end
 #   end
 # end
-describe AnnouncementsHelper do
+describe AnnouncementsHelper, :type => :helper do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/helpers/log_helper_spec.rb
+++ b/spec/helpers/log_helper_spec.rb
@@ -4,25 +4,25 @@ require 'spec_helper.rb'
 # difficulties -- rather than accessing the value returned by function, it
 # sees the intermediary Proc. Therefore, the trusty `should` is used instead.
 
-describe "transform_attributes" do
+describe "transform_attributes", :type => :helper do
   include LogHelper
 
   context "with unrecognized key" do
     context "during key transformation" do
       subject { transform_attributes(['id_checked_at_time', nil])[0] }
-      it { should_not include '_' }
-      it { should include 'I', 'C', 'A', 'T'}
-      it { should include 'ID' }
-      it { should eq("ID Checked At Time") }
+      it { is_expected.not_to include '_' }
+      it { is_expected.to include 'I', 'C', 'A', 'T'}
+      it { is_expected.to include 'ID' }
+      it { is_expected.to eq("ID Checked At Time") }
     end
 
     context "during value transformation" do
       it "transforms nil to N/A" do
-        transform_attributes(['not_an_attribute', nil])[1].should == "N/A"
+        expect(transform_attributes(['not_an_attribute', nil])[1]).to eq("N/A")
       end
       it "doesn't transform constant values" do
         [1, true, 'true'].each do |x|
-          transform_attributes(['not_an_attribute', x])[1].should == x
+          expect(transform_attributes(['not_an_attribute', x])[1]).to eq(x)
         end
       end
     end
@@ -32,54 +32,54 @@ describe "transform_attributes" do
     it "converts existing reserver/check-in handler/check-out handler ID into proper link" do
       user = FactoryGirl.create(:user)
       %w(reserver_id checkin_handler_id checkout_handler_id).each do |k|
-        transform_attributes( [k, user.id] )[1].should == link_to(user.name, User.find(user.id))
+        expect(transform_attributes( [k, user.id] )[1]).to eq(link_to(user.name, User.find(user.id)))
       end
     end
 
     it "converts non-existent reserver ID into N/A" do
       %w(reserver_id checkin_handler_id checkout_handler_id).each do |k|
-        transform_attributes( [k, nil] )[1].should == 'N/A'
+        expect(transform_attributes( [k, nil] )[1]).to eq('N/A')
       end
     end
 
     it "converts existing reservation ID into proper link" do
       res = FactoryGirl.create(:valid_reservation)
-      transform_attributes( ['reservation_id', res.id] )[1].should == link_to("#{res.id} (see current)", Reservation.find(res.id))
+      expect(transform_attributes( ['reservation_id', res.id] )[1]).to eq(link_to("#{res.id} (see current)", Reservation.find(res.id)))
     end
 
     it "doesn't convert defunct reservation ID into proper link" do
-      transform_attributes( ['reservation_id', 0] )[1].should == "0 (deleted)"
+      expect(transform_attributes( ['reservation_id', 0] )[1]).to eq("0 (deleted)")
     end
 
     it "converts existing equipment model ID into proper link" do
       eqm = FactoryGirl.create(:equipment_model)
-      transform_attributes( ['equipment_model_id', eqm.id] )[1].should == link_to("#{eqm.name}", EquipmentModel.find(eqm.id))
+      expect(transform_attributes( ['equipment_model_id', eqm.id] )[1]).to eq(link_to("#{eqm.name}", EquipmentModel.find(eqm.id)))
     end
 
     it "doesn't convert defunct equipment model into a link" do
-      transform_attributes( ['equipment_model_id', 0] )[1].should == "Model ID 0 (deleted)"
+      expect(transform_attributes( ['equipment_model_id', 0] )[1]).to eq("Model ID 0 (deleted)")
     end
 
     it "converts existing equipment object ID into proper link" do
       eqo = FactoryGirl.create(:equipment_object)
-      transform_attributes( ['equipment_object_id', eqo.id] )[1].should == link_to("#{eqo.name}", EquipmentObject.find(eqo.id))
+      expect(transform_attributes( ['equipment_object_id', eqo.id] )[1]).to eq(link_to("#{eqo.name}", EquipmentObject.find(eqo.id)))
     end
 
     it "doesn't convert defunct equipment object into a link" do
-      transform_attributes( ['equipment_object_id', 0] )[1].should == "N/A"
+      expect(transform_attributes( ['equipment_object_id', 0] )[1]).to eq("N/A")
     end
 
     it "converts start date and due date to readable form (Mon DD, YYYY)" do
       date = DateTime.now
       %w(start_date due_date).each do |k|
-        transform_attributes( [k, date] )[1].should == date.strftime("%B %d, %Y")
+        expect(transform_attributes( [k, date] )[1]).to eq(date.strftime("%B %d, %Y"))
       end
     end
 
     it "converts creation, update, check-in, and check-out time to readable form" do
       date = DateTime.now
       %w(created_at updated_at checked_in checked_out).each do |k|
-        transform_attributes( [k, date] )[1].should == date.strftime("%B %d, %Y, %H:%M:%S, %z")
+        expect(transform_attributes( [k, date] )[1]).to eq(date.strftime("%B %d, %Y, %H:%M:%S, %z"))
       end
     end
   end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -10,11 +10,11 @@ shared_examples_for "a valid admin email" do
     expect(@mail.from.first).to eq("no-reply@reservations.app")
   end
   it "should actually send the email" do
-    ActionMailer::Base.deliveries.count.should eq(1)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
   end
 end
 
-describe AdminMailer do
+describe AdminMailer, :type => :mailer do
   before(:all) {
     @app_config = FactoryGirl.create(:app_config)
   }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -6,7 +6,7 @@ shared_examples_for "valid user email" do
     expect(@mail.to.first).to eq(reserver.email)
   end
   it "sends an email" do
-    ActionMailer::Base.deliveries.count.should eq(1)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
   end
   # FIXME: Workaround for #398 disables this functionality for RSpec testing
   # it "is from the admin" do
@@ -15,7 +15,7 @@ shared_examples_for "valid user email" do
   # end
 end
 
-describe UserMailer do
+describe UserMailer, :type => :mailer do
   before(:all) {
     @app_config = FactoryGirl.create(:app_config)
   }

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Announcement do
+describe Announcement, :type => :model do
   #pending "add some examples to (or delete) #{__FILE__}"
   it "has current scope" do
     passed = Announcement.create! starts_at: 1.day.ago, ends_at: 1.hour.ago, message: "MyText"
@@ -15,12 +15,12 @@ describe Announcement do
 
     current2 = Announcement.create! starts_at: 1.hour.ago, ends_at: 1.day.from_now, message: "MyText"
 
-    Announcement.current([current2.id]).should eq([current1])
+    expect(Announcement.current([current2.id])).to eq([current1])
   end
 
   it "includes current when nil is passed in" do
     current = Announcement.create! starts_at: 1.hour.ago, ends_at: 1.day.from_now, message: "MyText"
 
-    Announcement.current(nil).should eq([current])
+    expect(Announcement.current(nil)).to eq([current])
   end
 end

--- a/spec/models/app_config_spec.rb
+++ b/spec/models/app_config_spec.rb
@@ -1,32 +1,32 @@
 require 'spec_helper'
 
-describe AppConfig do
+describe AppConfig, :type => :model do
   before(:each) do
     @ac = FactoryGirl.build(:app_config)
   end
   it "has a working factory" do
-    @ac.save.should be_truthy
+    expect(@ac.save).to be_truthy
   end
   it "does not accept empty site title" do
     @ac.site_title = nil
-    @ac.should_not be_valid
+    expect(@ac).not_to be_valid
     @ac.site_title = " "
-    @ac.should_not be_valid
+    expect(@ac).not_to be_valid
   end
   it "does not accept too long a site title" do
     @ac.site_title = "AaaaaBbbbbCccccDddddEeeee"
-    @ac.should_not be_valid
+    expect(@ac).not_to be_valid
   end
   it "shouldn't have an invalid e-mail" do
     emails = ["ana@com", "anda@pres,com", nil, " "]
     emails.each do |invalid|
       @ac.admin_email = invalid
-      @ac.should_not be_valid
+      expect(@ac).not_to be_valid
     end
   end
   it "should have a valid and present e-mail" do
     @ac.admin_email = "ana@yale.edu"
-    @ac.should be_valid
+    expect(@ac).to be_valid
   end
   # it "has an attachment that could serve as favicon" do
   #   @ac.favicon_file_name = "icon.ico"
@@ -40,7 +40,7 @@ describe AppConfig do
     types = ["image/gif", "image/jpeg", "image/png"]
     types.each do |invalid|
       @ac.favicon_content_type = invalid
-      @ac.should_not be_valid
+      expect(@ac).not_to be_valid
     end
     @ac.favicon_content_type = "image/vnd.microsoft.icon"
   end

--- a/spec/models/blackout_spec.rb
+++ b/spec/models/blackout_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe Blackout do
+describe Blackout, :type => :model do
   context "validations and associations" do
-    it { should validate_presence_of(:notice) }
-    it { should validate_presence_of(:start_date) }
-    it { should validate_presence_of(:end_date) }
-    it { should validate_presence_of(:blackout_type) }
+    it { is_expected.to validate_presence_of(:notice) }
+    it { is_expected.to validate_presence_of(:start_date) }
+    it { is_expected.to validate_presence_of(:end_date) }
+    it { is_expected.to validate_presence_of(:blackout_type) }
 
     it "validates a set_id if it is a recurring blackout"
       # new feature that should exist already

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
-describe Cart do
+describe Cart, :type => :model do
   before (:each) do
     @cart = FactoryGirl.build(:cart)
     @cart.items = {} # Needed to avoid db flushing problems
   end
 
   it "has a working factory" do
-    @cart.should be_valid
+    expect(@cart).to be_valid
   end
 
   context "General validations" do
-    it { should validate_presence_of(:reserver_id) }
-    it { should validate_presence_of(:start_date) }
-    it { should validate_presence_of(:due_date) }
+    it { is_expected.to validate_presence_of(:reserver_id) }
+    it { is_expected.to validate_presence_of(:start_date) }
+    it { is_expected.to validate_presence_of(:due_date) }
   end
 
   describe ".initialize" do
@@ -35,7 +35,7 @@ describe Cart do
   end
 
   describe ".persisted?" do
-    it { @cart.persisted?.should be_falsey }
+    it { expect(@cart.persisted?).to be_falsey }
   end
 
   describe "Item handling" do
@@ -126,13 +126,13 @@ describe Cart do
 
     describe ".duration" do
       it "should calculate the sum correctly" do
-        @cart.duration.should == @cart.due_date - @cart.start_date + 1
+        expect(@cart.duration).to eq(@cart.due_date - @cart.start_date + 1)
       end
     end
 
     describe ".reserver" do
       it "should return a correct user instance" do
-        @cart.reserver.should == User.find(@cart.reserver_id)
+        expect(@cart.reserver).to eq(User.find(@cart.reserver_id))
       end
     end
   end
@@ -140,11 +140,11 @@ describe Cart do
   describe ".empty?" do
     it "is true when there are no items in cart" do
       @cart.items = []
-      @cart.empty?.should be_truthy
+      expect(@cart.empty?).to be_truthy
     end
     it "is false when there are some items in cart" do
       @cart.add_item(FactoryGirl.create(:equipment_model))
-      @cart.empty?.should be_falsey
+      expect(@cart.empty?).to be_falsey
     end
   end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
-describe Category do
+describe Category, :type => :model do
   before(:each) do
     @category = FactoryGirl.build(:category)
   end
 
-  it { should validate_presence_of(:name) }
-  it { should validate_uniqueness_of(:name) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
 
-  it { should have_many(:equipment_models) }
+  it { is_expected.to have_many(:equipment_models) }
 
   # validate numericality for :max_renewal_length, :max_renewal_times, :renewal_days_before_due, :max_per_user, :sort_order, :max_checkout_length
   # this includes integer_only, and greater_than_or_equal_to => 0
@@ -16,109 +16,109 @@ describe Category do
   # :max_renewal_length
   it "validates max_renewal_length must be non-negative" do
     @category.max_renewal_length = -1
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_renewal_length = 0
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_renewal_length can be nil" do
     @category.max_renewal_length = nil
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_renewal_length must be an integer" do
     @category.max_renewal_length = "not_an_integer"
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_renewal_length = 1
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
 
   # :max_renewal_times
   it "validates max_renewal_times must be non-negative" do
     @category.max_renewal_times = -1
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_renewal_times = 0
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_renewal_times can be nil" do
     @category.max_renewal_times = nil
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_renewal_times must be an integer" do
     @category.max_renewal_times = "not_an_integer"
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_renewal_times = 1
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
 
   # :renewal_days_before_due
   it "validates renewal_days_before_due must be non-negative" do
     @category.renewal_days_before_due = -1
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.renewal_days_before_due = 0
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates renewal_days_before_due can be nil" do
     @category.renewal_days_before_due = nil
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates renewal_days_before_due must be an integer" do
     @category.renewal_days_before_due = "not_an_integer"
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.renewal_days_before_due = 1
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
 
   # :sort_order
   it "validates sort_order must be non-negative" do
     @category.sort_order = -1
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.sort_order = 0
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates sort_order can be nil" do
     @category.sort_order = nil
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates sort_order must be an integer" do
     @category.sort_order = "not_an_integer"
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.sort_order = 1
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
 
   # :max_per_user
   it "validates max_per_user must be non-negative" do
     @category.max_per_user = -1
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_per_user = 0
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_per_user can be nil" do
     @category.max_per_user = nil
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_per_user must be an integer" do
     @category.max_per_user = "not_an_integer"
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_per_user = 1
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
 
   # :max_checkout_length
   it "validates max_checkout_length must be non-negative" do
     @category.max_checkout_length = -1
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_checkout_length = 0
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_checkout_length can be nil" do
     @category.max_checkout_length = nil
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
   it "validates max_checkout_length must be an integer" do
     @category.max_checkout_length = "not_an_integer"
-    @category.save.should be_falsey
+    expect(@category.save).to be_falsey
     @category.max_checkout_length = 1
-    @category.save.should be_truthy
+    expect(@category.save).to be_truthy
   end
 
   # custom scope to return active categories
@@ -129,11 +129,11 @@ describe Category do
     end
 
     it "Should return all active categories" do
-      Category.active.should include(@category)
+      expect(Category.active).to include(@category)
     end
 
     it "Should not return inactive categories" do
-      Category.active.should_not include(@deactivated)
+      expect(Category.active).not_to include(@deactivated)
     end
   end
 
@@ -144,10 +144,10 @@ describe Category do
       @unrestrected_category = FactoryGirl.create(:category, max_per_user: nil)
     end
     it "Should return maximum_per_user if defined" do
-      @category.maximum_per_user.should == 1
+      expect(@category.maximum_per_user).to eq(1)
     end
     it "Should return Float::INFINITY if not defined" do
-      @unrestrected_category.maximum_per_user.should == Float::INFINITY
+      expect(@unrestrected_category.maximum_per_user).to eq(Float::INFINITY)
     end
   end
 
@@ -158,10 +158,10 @@ describe Category do
       @unrestrected_category = FactoryGirl.create(:category, max_renewal_length: nil)
     end
     it "Should return maximum_renewal_length if defined" do
-      @category.maximum_renewal_length.should == 5
+      expect(@category.maximum_renewal_length).to eq(5)
     end
     it "Default to 0 if not defined" do
-      @unrestrected_category.maximum_renewal_length.should == 0
+      expect(@unrestrected_category.maximum_renewal_length).to eq(0)
     end
   end
 
@@ -172,10 +172,10 @@ describe Category do
       @unrestrected_category = FactoryGirl.create(:category, max_renewal_times: nil)
     end
     it "Should return maximum_renewal_times if defined" do
-      @category.maximum_renewal_times.should == 1
+      expect(@category.maximum_renewal_times).to eq(1)
     end
     it "Default to infinity if not defined" do
-      @unrestrected_category.maximum_renewal_times.should == Float::INFINITY
+      expect(@unrestrected_category.maximum_renewal_times).to eq(Float::INFINITY)
     end
   end
 
@@ -186,10 +186,10 @@ describe Category do
       @unrestrected_category = FactoryGirl.create(:category, renewal_days_before_due: nil)
     end
     it "Should return maximum_renewal_days_before_due if defined" do
-      @category.maximum_renewal_days_before_due.should == 1
+      expect(@category.maximum_renewal_days_before_due).to eq(1)
     end
     it "Default to infinity if not defined" do
-      @unrestrected_category.maximum_renewal_days_before_due.should == Float::INFINITY
+      expect(@unrestrected_category.maximum_renewal_days_before_due).to eq(Float::INFINITY)
     end
   end
 
@@ -200,10 +200,10 @@ describe Category do
       @unrestrected_category = FactoryGirl.create(:category, max_checkout_length: nil)
     end
     it "Should return maximum_checkout_length if defined" do
-      @category.maximum_checkout_length.should == 5
+      expect(@category.maximum_checkout_length).to eq(5)
     end
     it "Default to infinity if not defined" do
-      @unrestrected_category.maximum_checkout_length.should == Float::INFINITY
+      expect(@unrestrected_category.maximum_checkout_length).to eq(Float::INFINITY)
     end
   end
 
@@ -214,12 +214,12 @@ describe Category do
       @hipster = FactoryGirl.create(:category, name: "Tumblr starbucks PBR slackline music hipster")
     end
     it "Should return names matching all of the query words" do
-      Category.catalog_search("Tumblr").should == [@category, @hipster]
-      Category.catalog_search("Tumblr hipster").should == [@category, @hipster]
+      expect(Category.catalog_search("Tumblr")).to eq([@category, @hipster])
+      expect(Category.catalog_search("Tumblr hipster")).to eq([@category, @hipster])
     end
     it "Should not return any categories without every query word in the name" do
-      Category.catalog_search("starbucks").should == [@hipster]
-      Category.catalog_search("Tumblr instagram sustainable").should == [@category]
+      expect(Category.catalog_search("starbucks")).to eq([@hipster])
+      expect(Category.catalog_search("Tumblr instagram sustainable")).to eq([@category])
     end
   end
 end

--- a/spec/models/checkin_procedure_spec.rb
+++ b/spec/models/checkin_procedure_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe CheckinProcedure do
-  it { should belong_to(:equipment_model) }
+describe CheckinProcedure, :type => :model do
+  it { is_expected.to belong_to(:equipment_model) }
 end

--- a/spec/models/checkout_procedure_spec.rb
+++ b/spec/models/checkout_procedure_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe CheckoutProcedure do
-  it { should belong_to(:equipment_model) }
+describe CheckoutProcedure, :type => :model do
+  it { is_expected.to belong_to(:equipment_model) }
 end

--- a/spec/models/equipment_model_spec.rb
+++ b/spec/models/equipment_model_spec.rb
@@ -1,129 +1,129 @@
 require 'spec_helper'
 
-describe EquipmentModel do
+describe EquipmentModel, :type => :model do
   context "basic validations" do
     before(:each) do
       @model = FactoryGirl.build(:equipment_model)
     end
 
     it "has a working factory" do
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
 
-    it { should belong_to(:category) }
-    it { should have_and_belong_to_many(:requirements) }
-    it { should have_many(:equipment_objects) }
+    it { is_expected.to belong_to(:category) }
+    it { is_expected.to have_and_belong_to_many(:requirements) }
+    it { is_expected.to have_many(:equipment_objects) }
 
     #TODO: figure out how to implement this in order to create a passing test (the model currently works but the test fails)
     # it { should have_many(:documents) }
 
-    it { should have_many(:reservations) }
-    it { should have_many(:checkin_procedures) }
-    it { should accept_nested_attributes_for(:checkin_procedures) }
-    it { should have_many(:checkout_procedures) }
-    it { should accept_nested_attributes_for(:checkout_procedures) }
-    it { should have_and_belong_to_many(:associated_equipment_models) }
+    it { is_expected.to have_many(:reservations) }
+    it { is_expected.to have_many(:checkin_procedures) }
+    it { is_expected.to accept_nested_attributes_for(:checkin_procedures) }
+    it { is_expected.to have_many(:checkout_procedures) }
+    it { is_expected.to accept_nested_attributes_for(:checkout_procedures) }
+    it { is_expected.to have_and_belong_to_many(:associated_equipment_models) }
 
-    it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:description) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:description) }
 
     it "requires an associated category" do
       @model.category = nil
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.category = FactoryGirl.create(:category)
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
 
-    it { should validate_uniqueness_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name) }
 
     it "requires a late fee greater than or equal to 0" do
       @model.late_fee = "-1.00"
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.late_fee = "0.00"
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
 
     it "requires a replacement fee greater than or equal to 0" do
       @model.replacement_fee = "-1.00"
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.replacement_fee = "0.00"
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
 
     # max_per_user
     # note: for some reason this allows a max_per_user value of "2.3" as a string to save properly.
     it "requires an integer value for maximum per user" do
       @model.max_per_user = 2.3
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.max_per_user = 2
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "requires a maximum per user value greater than or equal to 1" do
       @model.max_per_user = -1
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.max_per_user = 0
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.max_per_user = 1
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     # only necessary because of integer requirement
     it "allows nil values for maximum per user" do
       @model.max_per_user = nil
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
 
     # max_renewal_length
     it "requires an integer value for maximum renewal length" do
       @model.max_renewal_length = 2.3
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.max_renewal_length = 2
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "requires a maximum renewal length value greater than or equal to 0" do
       @model.max_renewal_length = -1
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.max_renewal_length = 0
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "allows nil values for maximum renewal length" do
       @model.max_renewal_length = nil
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
 
     # max_renewal_times
     it "requires an integer value for maximum renewal times" do
       @model.max_renewal_times = 2.3
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.max_renewal_times = 2
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "requires a maximum renewal times value greater than or equal to 0" do
       @model.max_renewal_times = -1
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.max_renewal_times = 0
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "allows nil values for maximum renewal times" do
       @model.max_renewal_times = nil
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
 
     # renewal_days_before_due
     it "requires an integer value for renewal days before due" do
       @model.renewal_days_before_due = 2.3
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.renewal_days_before_due = 2
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "requires a renewal days before due value greater than or equal to 0" do
       @model.renewal_days_before_due = -1
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
       @model.renewal_days_before_due = 0
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "allows nil values for renewal days before due" do
       @model.renewal_days_before_due = nil
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
   end
 
@@ -133,17 +133,17 @@ describe EquipmentModel do
       @model = FactoryGirl.create(:equipment_model, id: @unique_id)
     end
     it "has a working association callback" do
-      @model.save.should be_truthy
+      expect(@model.save).to be_truthy
     end
     it "does not permit association with itself" do
       @model.associated_equipment_model_ids = [@unique_id]
-      @model.save.should be_falsey
+      expect(@model.save).to be_falsey
     end
     describe ".not_associated_with_self" do
       it "creates an error if associated with self" do
         @model.associated_equipment_model_ids = [@unique_id]
         @model.not_associated_with_self
-        @model.errors.first.should be_truthy
+        expect(@model.errors.first).to be_truthy
       end
     end
   end
@@ -161,15 +161,15 @@ describe EquipmentModel do
                                                                                     mi aesthetic, ennui Marfa kitsch readymade vegan food truck bag." )
       end
       it "Should return equipment_models with all of the query words in either name or description" do
-        EquipmentModel.catalog_search("Tumblr").should == [@model, @another_model]
-        EquipmentModel.catalog_search("Tumblr hipster").should == [@model, @another_model]
-        EquipmentModel.catalog_search("Tumblr bag").should == [@model, @another_model]
-        EquipmentModel.catalog_search("jean shorts vegan").should == [@model, @another_model]
+        expect(EquipmentModel.catalog_search("Tumblr")).to eq([@model, @another_model])
+        expect(EquipmentModel.catalog_search("Tumblr hipster")).to eq([@model, @another_model])
+        expect(EquipmentModel.catalog_search("Tumblr bag")).to eq([@model, @another_model])
+        expect(EquipmentModel.catalog_search("jean shorts vegan")).to eq([@model, @another_model])
       end
       it "Should not return any equipment_models without every query word in the name or description" do
-        EquipmentModel.catalog_search("starbucks").should == [@another_model]
-        EquipmentModel.catalog_search("Tumblr hipster woodstock PBR").should == [@model]
-        EquipmentModel.catalog_search("Craft beer sartorial four loko").should == [@another_model]
+        expect(EquipmentModel.catalog_search("starbucks")).to eq([@another_model])
+        expect(EquipmentModel.catalog_search("Tumblr hipster woodstock PBR")).to eq([@model])
+        expect(EquipmentModel.catalog_search("Craft beer sartorial four loko")).to eq([@another_model])
       end
     end
     describe "#select_options" do
@@ -184,38 +184,38 @@ describe EquipmentModel do
     end
     describe ".maximum_per_user" do
       it "should return the max_per_user if specified" do
-        @model.maximum_per_user.should == @model.max_per_user
+        expect(@model.maximum_per_user).to eq(@model.max_per_user)
       end
       it "should return the associated category's max_per_user if unspecified" do
         @model.max_per_user = nil
-        @model.maximum_per_user.should == @category.maximum_per_user
+        expect(@model.maximum_per_user).to eq(@category.maximum_per_user)
       end
     end
     describe ".maximum_renewal_length" do
       it "should return the max_renewal_length if specified" do
-        @model.maximum_renewal_length.should == @model.max_renewal_length
+        expect(@model.maximum_renewal_length).to eq(@model.max_renewal_length)
       end
       it "should return the associated category's max_renewal_length if unspecified" do
         @model.max_renewal_length = nil
-        @model.maximum_renewal_length.should == @category.maximum_renewal_length
+        expect(@model.maximum_renewal_length).to eq(@category.maximum_renewal_length)
       end
     end
     describe ".maximum_renewal_times" do
       it "should return the max_renewal_times if specified" do
-        @model.maximum_renewal_times.should == @model.max_renewal_times
+        expect(@model.maximum_renewal_times).to eq(@model.max_renewal_times)
       end
       it "should return the associated category's max_renewal_length if unspecified" do
         @model.max_renewal_times = nil
-        @model.maximum_renewal_times.should == @category.maximum_renewal_times
+        expect(@model.maximum_renewal_times).to eq(@category.maximum_renewal_times)
       end
     end
     describe ".maximum_renewal_days_before_due" do
       it "should return the model's renewal_days_before_due if specified" do
-        @model.maximum_renewal_days_before_due.should == @model.renewal_days_before_due
+        expect(@model.maximum_renewal_days_before_due).to eq(@model.renewal_days_before_due)
       end
       it "should return the associated category's renewal_days_before_due if unspecified" do
         @model.renewal_days_before_due = nil
-        @model.maximum_renewal_days_before_due.should == @category.maximum_renewal_days_before_due
+        expect(@model.maximum_renewal_days_before_due).to eq(@category.maximum_renewal_days_before_due)
       end
     end
 
@@ -232,20 +232,20 @@ describe EquipmentModel do
       end
       it "should return false if the user has fulfilled the requirements to use the model" do
         @user = FactoryGirl.create(:user, requirements: [@requirement, @requirement2])
-        @model.model_restricted?(@user.id).should be_falsey
+        expect(@model.model_restricted?(@user.id)).to be_falsey
       end
       it "should return false if the model has no requirements" do
         @model.requirements = []
         @user = FactoryGirl.create(:user, requirements: [@requirement, @requirement2])
-        @model.model_restricted?(@user.id).should be_falsey
+        expect(@model.model_restricted?(@user.id)).to be_falsey
       end
       it "should return true if the user has not fulfilled all of the requirements" do
         @user = FactoryGirl.create(:user, requirements: [@requirement])
-        @model.model_restricted?(@user.id).should be_truthy
+        expect(@model.model_restricted?(@user.id)).to be_truthy
       end
       it "should return true if the user has not fulfilled any of the requirements" do
         @user = FactoryGirl.create(:user)
-        @model.model_restricted?(@user.id).should be_truthy
+        expect(@model.model_restricted?(@user.id)).to be_truthy
       end
     end
 
@@ -255,12 +255,12 @@ describe EquipmentModel do
         it "should return the number of objects of that model available over a given date range" do
           @reservation = FactoryGirl.create(:valid_reservation, equipment_model: @model)
           @extra_object = FactoryGirl.create(:equipment_object, equipment_model: @model)
-          @model.equipment_objects.size.should eq(2)
-          @model.num_available(@reservation.start_date, @reservation.due_date).should eq(1)
+          expect(@model.equipment_objects.size).to eq(2)
+          expect(@model.num_available(@reservation.start_date, @reservation.due_date)).to eq(1)
         end
         it "should return 0 if no objects of that model are available" do
           @reservation = FactoryGirl.create(:valid_reservation, equipment_model: @model)
-          @model.num_available(@reservation.start_date, @reservation.due_date).should eq(0)
+          expect(@model.num_available(@reservation.start_date, @reservation.due_date)).to eq(0)
         end
       end
       describe ".number_overdue" do
@@ -268,8 +268,8 @@ describe EquipmentModel do
           @reservation = FactoryGirl.build(:overdue_reservation, equipment_model: @model)
           @reservation.save(validate: false)
           @extra_object = FactoryGirl.create(:equipment_object, equipment_model: @model)
-          @model.equipment_objects.size.should eq(2)
-          @model.number_overdue.should eq(1)
+          expect(@model.equipment_objects.size).to eq(2)
+          expect(@model.number_overdue).to eq(1)
         end
       end
       describe ".available_count" do
@@ -281,15 +281,15 @@ describe EquipmentModel do
           FactoryGirl.create(:checked_out_reservation, equipment_model: @model)
           @overdue = FactoryGirl.build(:overdue_reservation, equipment_model: @model)
           @overdue.save(validate: false)
-          @model.equipment_objects.size.should eq(4)
-          @model.available_count(Date.current).should eq(1)
+          expect(@model.equipment_objects.size).to eq(4)
+          expect(@model.available_count(Date.current)).to eq(1)
         end
       end
       describe ".available_object_select_options" do
         it "should make a string listing the available objects" do
           @reservation = FactoryGirl.create(:checked_out_reservation, equipment_model: @model)
           @object = FactoryGirl.create(:equipment_object, equipment_model: @model)
-          @model.available_object_select_options.should eq("<option value=#{@object.id}>#{@object.name}</option>")
+          expect(@model.available_object_select_options).to eq("<option value=#{@object.id}>#{@object.name}</option>")
         end
       end
     end

--- a/spec/models/equipment_object_spec.rb
+++ b/spec/models/equipment_object_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe EquipmentObject do
+describe EquipmentObject, :type => :model do
   context "validations" do
     before(:each) do
       @object = FactoryGirl.build(:equipment_object)
     end
 
     it "has a working factory" do
-      @object.save.should be_truthy
+      expect(@object.save).to be_truthy
     end
 
-    it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:equipment_model) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:equipment_model) }
 
     # this test passes even without the nilify_blanks call in the model, maybe delete the call?
     it "saves an empty string value as nil for deleted_at field" do
       @object.deleted_at = "   "
       @object.save
-      @object.deleted_at.should == nil
+      expect(@object.deleted_at).to eq(nil)
     end
   end
 
@@ -28,54 +28,54 @@ describe EquipmentObject do
     end
 
     it "Should return all active equipment objects" do
-      EquipmentObject.active.should include(@active)
+      expect(EquipmentObject.active).to include(@active)
     end
 
     it "Should not return inactive equipment objects" do
-      EquipmentObject.active.should_not include(@deactivated)
+      expect(EquipmentObject.active).not_to include(@deactivated)
     end
   end
 
   describe ".status" do
     it "returns 'Deactivated' if the object has a value for deleted_at" do
       @object = FactoryGirl.create(:equipment_object, deleted_at: Date.current)
-      @object.status.should == 'Deactivated'
+      expect(@object.status).to eq('Deactivated')
     end
     it "returns 'available' if the object is active and not currently checked out" do
       @object = FactoryGirl.create(:equipment_object)
-      @object.status.should == 'available'
+      expect(@object.status).to eq('available')
       @reservation = FactoryGirl.create(:valid_reservation)
       @reserved_object = EquipmentObject.find_by_equipment_model_id(@reservation.equipment_model.id)
-      @reserved_object.status.should == 'available'
+      expect(@reserved_object.status).to eq('available')
     end
     it "returns a description of the reservation that it is currently associated with if it is active and checked out" do
       @reservation = FactoryGirl.create(:checked_out_reservation)
       @checked_out_object = @reservation.equipment_object
-      @checked_out_object.status.should == "checked out by #{@reservation.reserver.name} through #{@reservation.due_date.strftime("%b %d")}"
+      expect(@checked_out_object.status).to eq("checked out by #{@reservation.reserver.name} through #{@reservation.due_date.strftime("%b %d")}")
     end
   end
 
   describe ".current_reservation" do
     it "returns nil if the equipment object does not have an associted reservation" do
       @object = FactoryGirl.create(:equipment_object)
-      @object.current_reservation.should be_nil
+      expect(@object.current_reservation).to be_nil
     end
     it "returns the reservation object currently holding this equipment_object if there is one that does" do
       @reservation = FactoryGirl.create(:checked_out_reservation)
       @reserved_object = @reservation.equipment_object
-      @reserved_object.current_reservation.should == @reservation
+      expect(@reserved_object.current_reservation).to eq(@reservation)
     end
   end
 
   describe ".available?" do
     it "returns true if the equipment object is not checked out" do
       @object = FactoryGirl.create(:equipment_object)
-      @object.available?.should be_truthy
+      expect(@object.available?).to be_truthy
     end
     it "returns false if the equipment object is currently checked out" do
       @reservation = FactoryGirl.create(:checked_out_reservation)
       @checked_out_object = @reservation.equipment_object
-      @checked_out_object.available?.should be_falsey
+      expect(@checked_out_object.available?).to be_falsey
     end
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe Message do
+describe Message, :type => :model do
   context "validations" do
-    it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:email) }
-    it { should validate_presence_of(:subject) }
-    it { should validate_presence_of(:body) }
-    it { should_not allow_value("abc", "!s@abc.com", "a@!d.com", "a@a.c0m").for(:email) }
-    it { should allow_value("example@example.com", "1a@a.edu", "a@2a.net").for(:email) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.not_to allow_value("abc", "!s@abc.com", "a@!d.com", "a@a.c0m").for(:email) }
+    it { is_expected.to allow_value("example@example.com", "1a@a.edu", "a@2a.net").for(:email) }
 
     # this test currently fails but I'm not sure why
     # also, why would we want to be able to leave email blank?
@@ -19,7 +19,7 @@ describe Message do
   describe ".persisted?" do
     it "should always return false" do
       @message = FactoryGirl.build(:message)
-      @message.persisted?.should be_falsey
+      expect(@message.persisted?).to be_falsey
     end
   end
 end

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
-describe Requirement do
+describe Requirement, :type => :model do
   context "Validations" do
     before(:each) do
       @requirement = FactoryGirl.build(:requirement)
     end
     it "has a working factory" do
-      @requirement.save.should be_truthy
+      expect(@requirement.save).to be_truthy
     end
 
-    it { should validate_presence_of(:contact_name) }
-    it { should validate_presence_of(:description) }
-    it { should validate_presence_of(:contact_info) }
-    it { should have_and_belong_to_many(:equipment_models) }
-    it { should have_and_belong_to_many(:users) }
+    it { is_expected.to validate_presence_of(:contact_name) }
+    it { is_expected.to validate_presence_of(:description) }
+    it { is_expected.to validate_presence_of(:contact_info) }
+    it { is_expected.to have_and_belong_to_many(:equipment_models) }
+    it { is_expected.to have_and_belong_to_many(:users) }
   end
 
   describe "#list_requirement_admins" do
@@ -29,14 +29,14 @@ describe Requirement do
       req_message = "This model requires proper training before it can be reserved. "\
             "Please contact #{@requirement.contact_name} and #{@another_requirement.contact_name} at "\
             "#{@requirement.contact_info} and #{@another_requirement.contact_info} about becoming certified."
-      Requirement.list_requirement_admins(@user_with_unmet_requirement, @equipment_model).should == req_message
+      expect(Requirement.list_requirement_admins(@user_with_unmet_requirement, @equipment_model)).to eq(req_message)
     end
 
     it "should return a list of met requirements, followed by unmet requirements if they exists" do
       req_message = "You have already met the requirements to check out this model set by #{@requirement.contact_name}. "\
             "However, this model requires additional training before it can be reserved. "\
             "Please contact #{@another_requirement.contact_name} at #{@another_requirement.contact_info} about becoming certified."
-      Requirement.list_requirement_admins(@user_that_meets_some_requirements, @equipment_model).should == req_message
+      expect(Requirement.list_requirement_admins(@user_that_meets_some_requirements, @equipment_model)).to eq(req_message)
     end
   end
 end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -3,16 +3,16 @@
 
 require 'spec_helper'
 
-describe Reservation do
+describe Reservation, :type => :model do
   subject(:reservation) { FactoryGirl.build(:valid_reservation) }
 
-  it { should belong_to(:equipment_model) }
-  it { should belong_to(:reserver) }
-  it { should belong_to(:equipment_object) }
-  it { should belong_to(:checkout_handler) }
-  it { should belong_to(:checkin_handler) }
+  it { is_expected.to belong_to(:equipment_model) }
+  it { is_expected.to belong_to(:reserver) }
+  it { is_expected.to belong_to(:equipment_object) }
+  it { is_expected.to belong_to(:checkout_handler) }
+  it { is_expected.to belong_to(:checkin_handler) }
   #it { should validate_presence_of(:reserver) } #fails because of the deleted reserver
-  it { should validate_presence_of(:equipment_model) }
+  it { is_expected.to validate_presence_of(:equipment_model) }
   #it { should validate_presence_of(:start_date) } #fails because validations can't run if nil (?)
   #it { should validate_presence_of(:due_date) } #fails because validations can't run if nil (?)
   #
@@ -54,33 +54,33 @@ describe Reservation do
   end
 
   context "when valid" do
-    it { should be_valid }
+    it { is_expected.to be_valid }
     it 'should have a valid reserver' do
-      reservation.reserver.should_not be_nil
-      reservation.reserver.first_name.should_not == "Deleted"
+      expect(reservation.reserver).not_to be_nil
+      expect(reservation.reserver.first_name).not_to eq("Deleted")
     end
     its(:equipment_model) { should_not be_nil }
     its(:start_date) { should_not be_nil }
     its(:due_date) { should_not be_nil }
     it 'should save' do
-      reservation.save.should be_truthy
-      Reservation.all.size.should == 1
-      Reservation.all.first.should == reservation
+      expect(reservation.save).to be_truthy
+      expect(Reservation.all.size).to eq(1)
+      expect(Reservation.all.first).to eq(reservation)
     end
     it 'can be updated' do
       reservation.due_date = Date.tomorrow + 1
-      reservation.save.should be_truthy
+      expect(reservation.save).to be_truthy
     end
     it 'passes custom validations' do
-      reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.matched_object_and_model.should be_nil
-      reservation.available.should be_nil
-      reservation.validate.should == []
+      expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.matched_object_and_model).to be_nil
+      expect(reservation.available).to be_nil
+      expect(reservation.validate).to eq([])
     end
-    it { should respond_to(:fake_reserver_id) }
-    it { should respond_to(:late_fee) }
-    it { should respond_to(:find_renewal_date) }
+    it { is_expected.to respond_to(:fake_reserver_id) }
+    it { is_expected.to respond_to(:late_fee) }
+    it { is_expected.to respond_to(:find_renewal_date) }
   end
 
   context 'when not checked out' do
@@ -92,21 +92,21 @@ describe Reservation do
     subject { FactoryGirl.build(:checked_out_reservation) }
 
     its(:status) { should == 'checked out' }
-    it { should be_is_eligible_for_renew }
+    it { is_expected.to be_is_eligible_for_renew }
   end
 
   context 'when checked in' do
     subject { FactoryGirl.build(:checked_in_reservation) }
 
     its(:status) { should == 'returned on time'}
-    it { should_not be_is_eligible_for_renew }
+    it { is_expected.not_to be_is_eligible_for_renew }
   end
 
   context 'when overdue' do
     subject { FactoryGirl.build(:overdue_reservation) }
 
     its(:status) { should == 'overdue' }
-    it { should be_is_eligible_for_renew } #should this be true?
+    it { is_expected.to be_is_eligible_for_renew } #should this be true?
   end
 
    context 'when missed' do
@@ -119,14 +119,14 @@ describe Reservation do
   context 'when empty' do
     subject(:reservation) { FactoryGirl.build(:reservation, equipment_model: nil) }
 
-    it { should_not be_valid }
+    it { is_expected.not_to be_valid }
     it 'should not save' do
-      reservation.save.should be_falsey
-      Reservation.all.size.should == 0
+      expect(reservation.save).to be_falsey
+      expect(Reservation.all.size).to eq(0)
     end
     it 'cannot be updated' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_falsey
+      expect(reservation.save).to be_falsey
     end
     # it 'fails appropriate validations' do
     #   reservation.should_not be_not_empty
@@ -147,63 +147,63 @@ describe Reservation do
     it 'updates with equipment model' do
       reservation.equipment_model = FactoryGirl.create(:equipment_model)
       FactoryGirl.create(:equipment_object, equipment_model: reservation.equipment_model)
-      reservation.save.should be_truthy
-      reservation.should be_valid
-      Reservation.all.size.should == 1
+      expect(reservation.save).to be_truthy
+      expect(reservation).to be_valid
+      expect(Reservation.all.size).to eq(1)
     end
   end
 
   context 'with past due date' do
     subject(:reservation) { FactoryGirl.build(:valid_reservation, due_date: Date.yesterday) }
 
-    it { should_not be_valid }
+    it { is_expected.not_to be_valid }
     it 'should not save' do
-      reservation.save.should be_falsey
-      Reservation.all.size.should == 0
+      expect(reservation.save).to be_falsey
+      expect(Reservation.all.size).to eq(0)
     end
     it 'cannot be updated' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_falsey
+      expect(reservation.save).to be_falsey
     end
     it 'fails appropriate validations' do
-      reservation.start_date_before_due_date.should_not be_nil
-      reservation.not_in_past.should_not be_nil
+      expect(reservation.start_date_before_due_date).not_to be_nil
+      expect(reservation.not_in_past).not_to be_nil
     end
     it 'passes other custom validations' do
-      reservation.not_empty.should be_nil
-      reservation.matched_object_and_model.should be_nil
-      reservation.available.should be_nil
-      reservation.validate.should eq([])
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.matched_object_and_model).to be_nil
+      expect(reservation.available).to be_nil
+      expect(reservation.validate).to eq([])
     end
     it 'updates with fixed date' do
       reservation.due_date = Date.tomorrow + 1.day
-      reservation.save.should be_truthy
-      reservation.should be_valid
-      Reservation.all.size.should == 1
+      expect(reservation.save).to be_truthy
+      expect(reservation).to be_valid
+      expect(Reservation.all.size).to eq(1)
     end
   end
 
   context 'with blacked out start date' do
     let!(:blackout) { FactoryGirl.create(:blackout, start_date: reservation.start_date, end_date: reservation.due_date) }
 
-    it { should be_valid }
+    it { is_expected.to be_valid }
     it 'should save' do
-      reservation.save.should be_truthy
-      Reservation.all.size.should == 1
+      expect(reservation.save).to be_truthy
+      expect(Reservation.all.size).to eq(1)
     end
     it 'can be updated' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_truthy
+      expect(reservation.save).to be_truthy
     end
     it 'fails appropriate validations' do
-      reservation.validate.should_not eq([])
+      expect(reservation.validate).not_to eq([])
     end
     it 'passes other custom validations' do
-      reservation.not_in_past.should be_nil
-      reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.matched_object_and_model.should be_nil
-      reservation.available.should be_nil
+      expect(reservation.not_in_past).to be_nil
+      expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.matched_object_and_model).to be_nil
+      expect(reservation.available).to be_nil
     end
   end
 
@@ -211,10 +211,10 @@ describe Reservation do
     subject(:reservation) { FactoryGirl.build(:valid_reservation, reserver: nil) }
 
     it 'should have a deleted user' do
-      reservation.reserver.should_not be_nil
-      reservation.reserver.first_name.should == "Deleted"
+      expect(reservation.reserver).not_to be_nil
+      expect(reservation.reserver.first_name).to eq("Deleted")
     end
-    it { should be_valid }
+    it { is_expected.to be_valid }
   end
 
   context 'when user has overdue reservation' do
@@ -226,25 +226,25 @@ describe Reservation do
       o
     }
 
-    it { should be_valid }
+    it { is_expected.to be_valid }
     it 'should not save' do
-      reservation.save.should be_truthy
-      Reservation.all.size.should == 2
-      Reservation.all.first.should == overdue
+      expect(reservation.save).to be_truthy
+      expect(Reservation.all.size).to eq(2)
+      expect(Reservation.all.first).to eq(overdue)
     end
     it 'can be updated' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_truthy
+      expect(reservation.save).to be_truthy
     end
     it 'fails appropriate validations' do
-      reservation.validate.should_not eq([])
+      expect(reservation.validate).not_to eq([])
     end
     it 'passes other custom validations' do
-       reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.matched_object_and_model.should be_nil
-      reservation.available.should be_nil
-      reservation.not_in_past.should be_nil
+       expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.matched_object_and_model).to be_nil
+      expect(reservation.available).to be_nil
+      expect(reservation.not_in_past).to be_nil
     end
   end
 
@@ -265,9 +265,9 @@ describe Reservation do
     #   Reservation.validate_set(reservation.reserver, [] << reservation).should_not == []
     # end
     it 'passes other custom validations' do
-      reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.not_in_past.should be_nil
+      expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.not_in_past).to be_nil
     end
   end
 
@@ -278,23 +278,23 @@ describe Reservation do
        r
      }
 
-    it { should_not be_valid }
+    it { is_expected.not_to be_valid }
     it 'should not save' do
-      reservation.save.should be_falsey
-      Reservation.all.size.should == 0
+      expect(reservation.save).to be_falsey
+      expect(Reservation.all.size).to eq(0)
     end
     it 'cannot be updated' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_falsey
+      expect(reservation.save).to be_falsey
     end
     it 'fails appropriate validations' do
-      reservation.matched_object_and_model.should_not be_nil
+      expect(reservation.matched_object_and_model).not_to be_nil
     end
     it 'passes other custom validations' do
-     reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.not_in_past.should be_nil
-      reservation.validate.should eq([])
+     expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.not_in_past).to be_nil
+      expect(reservation.validate).to eq([])
     end
   end
 
@@ -307,24 +307,24 @@ describe Reservation do
       r
     }
 
-    it { should be_valid }
+    it { is_expected.to be_valid }
     it 'should save' do
-      reservation.save.should be_truthy
-      Reservation.all.size.should == 1
+      expect(reservation.save).to be_truthy
+      expect(Reservation.all.size).to eq(1)
     end
     it 'can update' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_truthy
+      expect(reservation.save).to be_truthy
     end
     it 'fails appropriate validations' do
-      reservation.validate.should_not eq([])
+      expect(reservation.validate).not_to eq([])
     end
     it 'passes other custom validations' do
-       reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.matched_object_and_model.should be_nil
-      reservation.available.should be_nil
-      reservation.not_in_past.should be_nil
+       expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.matched_object_and_model).to be_nil
+      expect(reservation.available).to be_nil
+      expect(reservation.not_in_past).to be_nil
     end
   end
 
@@ -342,24 +342,24 @@ describe Reservation do
     }
 
 
-    it { should be_valid }
+    it { is_expected.to be_valid }
     it 'should save' do
-      reservation.save.should be_truthy
-      Reservation.all.size.should == 2
+      expect(reservation.save).to be_truthy
+      expect(Reservation.all.size).to eq(2)
     end
     it 'can be updated' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_truthy
+      expect(reservation.save).to be_truthy
     end
     it 'fails appropriate validations' do
-      reservation.validate.should_not eq([])
+      expect(reservation.validate).not_to eq([])
     end
     it 'passes other custom validations' do
-       reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.matched_object_and_model.should be_nil
-      reservation.available.should be_nil
-      reservation.not_in_past.should be_nil
+       expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.matched_object_and_model).to be_nil
+      expect(reservation.available).to be_nil
+      expect(reservation.not_in_past).to be_nil
     end
   end
 
@@ -376,24 +376,24 @@ describe Reservation do
       r
     }
 
-    it { should be_valid }
+    it { is_expected.to be_valid }
     it 'should save' do
-      reservation.save.should be_truthy
-      Reservation.all.size.should == 2
+      expect(reservation.save).to be_truthy
+      expect(Reservation.all.size).to eq(2)
     end
     it 'can be updated' do
       reservation.start_date = Date.tomorrow
-      reservation.save.should be_truthy
+      expect(reservation.save).to be_truthy
     end
     it 'fails appropriate validations' do
-      reservation.validate.should_not eq([])
+      expect(reservation.validate).not_to eq([])
     end
     it 'passes other custom validations' do
-       reservation.start_date_before_due_date.should be_nil
-      reservation.not_empty.should be_nil
-      reservation.matched_object_and_model.should be_nil
-      reservation.available.should be_nil
-      reservation.not_in_past.should be_nil
+       expect(reservation.start_date_before_due_date).to be_nil
+      expect(reservation.not_empty).to be_nil
+      expect(reservation.matched_object_and_model).to be_nil
+      expect(reservation.available).to be_nil
+      expect(reservation.not_in_past).to be_nil
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe User do
+describe User, :type => :model do
   it "has a working factory" do
-    FactoryGirl.create(:user).should be_valid
+    expect(FactoryGirl.create(:user)).to be_valid
   end
 
   context "validations and associations" do
@@ -10,17 +10,17 @@ describe User do
       @user = FactoryGirl.create(:user)
     end
 
-    it { should have_many(:reservations) }
-    it { should have_and_belong_to_many(:requirements) }
+    it { is_expected.to have_many(:reservations) }
+    it { is_expected.to have_and_belong_to_many(:requirements) }
 
-    it { should validate_presence_of(:login) }
-    it { should validate_uniqueness_of(:login) }
-    it { should validate_presence_of(:first_name) }
-    it { should validate_presence_of(:last_name) }
-    it { should validate_presence_of(:affiliation) }
-    it { should validate_presence_of(:email) }
-    it { should_not allow_value("abc", "!s@abc.com", "a@!d.com", "a@a.c0m").for(:email) }
-    it { should allow_value("example@example.com", "1a@a.edu", "a@2a.net").for(:email) }
+    it { is_expected.to validate_presence_of(:login) }
+    it { is_expected.to validate_uniqueness_of(:login) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:affiliation) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.not_to allow_value("abc", "!s@abc.com", "a@!d.com", "a@a.c0m").for(:email) }
+    it { is_expected.to allow_value("example@example.com", "1a@a.edu", "a@2a.net").for(:email) }
 
     # These tests are commented because currently, the app does not validate
     # phone unless that option is specifically requested by the admin. This
@@ -30,21 +30,21 @@ describe User do
     # it { should_not allow_value("abcdef", "555-555-55$5").for(:phone) }
     # it { should allow_value("555-555-5555", "15555555555").for(:phone) }
 
-    it { should_not allow_value("ab@", "ab1", "ab_c").for(:nickname) }
-    it { should allow_value(nil, "", "abc", "Example").for(:nickname) }
+    it { is_expected.not_to allow_value("ab@", "ab1", "ab_c").for(:nickname) }
+    it { is_expected.to allow_value(nil, "", "abc", "Example").for(:nickname) }
 
     #TODO: figure out why it's saving with terms_of_service_accepted = false
     it "must accept ToS" do
      # @user.terms_of_service_accepted = nil
      #  @user.save.should be_nil
        @user.terms_of_service_accepted = true
-       @user.save.should be_truthy
+       expect(@user.save).to be_truthy
     end
 
     # this test means nothing if the previous one fails
     it "doesn't have to accept ToS if created by an admin" do
       @user_made_by_admin = FactoryGirl.build(:user, created_by_admin: true, terms_of_service_accepted: false)
-      @user_made_by_admin.save.should be_truthy
+      expect(@user_made_by_admin.save).to be_truthy
     end
   end
 
@@ -54,7 +54,7 @@ describe User do
     end
 
     it "should default to empty string" do
-      @user.nickname.should == ''
+      expect(@user.nickname).to eq('')
     end
 
     it "should not allow nil" do
@@ -74,22 +74,22 @@ describe User do
     end
 
     it "should return all active users" do
-      User.active.should include(@user)
+      expect(User.active).to include(@user)
     end
 
     it "should not return inactive users" do
-      User.active.should_not include(@deactivated)
+      expect(User.active).not_to include(@deactivated)
     end
   end
 
   describe ".name" do
     it "should return the nickname and last name joined into one string if nickname is specified" do
       @user = FactoryGirl.create(:user, nickname: "Sasha Fierce")
-      @user.name.should == "#{@user.nickname} #{@user.last_name}"
+      expect(@user.name).to eq("#{@user.nickname} #{@user.last_name}")
     end
     it "should return the first and last name if user has no nickname specified" do
       @no_nickname = FactoryGirl.create(:user)
-      @no_nickname.name.should == "#{@no_nickname.first_name} #{@no_nickname.last_name}"
+      expect(@no_nickname.name).to eq("#{@no_nickname.first_name} #{@no_nickname.last_name}")
     end
   end
 
@@ -100,7 +100,7 @@ describe User do
     it "should return all equipment_objects reserved by the user" do
       @user = FactoryGirl.create(:user)
       @reservation = FactoryGirl.create(:valid_reservation, reserver: @user)
-      @user.equipment_objects.should == [@reservation.equipment_object]
+      expect(@user.equipment_objects).to eq([@reservation.equipment_object])
     end
   end
 
@@ -114,18 +114,18 @@ describe User do
     it "should return an array of all users ordered by last name, each represented by an array like this: ['first_name last_name', id]" do
       @user1 = FactoryGirl.create(:user, first_name: "Joseph", last_name: "Smith", nickname: "Joe")
       @user2 = FactoryGirl.create(:user, first_name: "Jessica", last_name: "Greene", nickname: "Jess")
-      User.select_options.should == [["#{@user2.last_name}, #{@user2.first_name}", @user2.id],["#{@user1.last_name}, #{@user1.first_name}", @user1.id]]
+      expect(User.select_options).to eq([["#{@user2.last_name}, #{@user2.first_name}", @user2.id],["#{@user1.last_name}, #{@user1.first_name}", @user1.id]])
     end
   end
 
   describe ".render_name" do
     it "should return the nickname, last name, and login id as a string if nickname exists" do
       @user = FactoryGirl.create(:user, nickname: "Sasha Fierce")
-      @user.render_name.should == "#{@user.nickname} #{@user.last_name} #{@user.login}"
+      expect(@user.render_name).to eq("#{@user.nickname} #{@user.last_name} #{@user.login}")
     end
     it "should return the first name, last name, and login id as a string if no nickname" do
       @no_nickname = FactoryGirl.create(:user)
-      @no_nickname.render_name.should == "#{@no_nickname.first_name} #{@no_nickname.last_name} #{@no_nickname.login}"
+      expect(@no_nickname.render_name).to eq("#{@no_nickname.first_name} #{@no_nickname.last_name} #{@no_nickname.login}")
     end
   end
 end

--- a/spec/requests/announcements_spec.rb
+++ b/spec/requests/announcements_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "Announcements" do
+describe "Announcements", :type => :request do
 	it "displays active announcements" do
   	Announcement.create! message: "Hello World", starts_at: 1.hour.ago, ends_at: 1.hour.from_now
   	Announcement.create! message: "Upcoming", starts_at: 10.minutes.from_now, ends_at: 1.hour.from_now
   	visit '/catalog'
-  	page.should have_content("Hello World")
-  	page.should_not have_content("Upcoming")
+  	expect(page).to have_content("Hello World")
+  	expect(page).not_to have_content("Upcoming")
     # check also that pressing the close button successfully closes the flash announcement.
     # for some reason capybara is not finding the button correctly -- someone with frontend
     # experience look at this?


### PR DESCRIPTION
This conversion is done by Transpec 2.3.6 with the following command:
    transpec -f
- 357 conversions
  from: obj.should
    to: expect(obj).to
- 246 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 152 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 80 conversions
  from: == expected
    to: eq(expected)
- 53 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 42 conversions
  from: it { should_not ... }
    to: it { is_expected.not_to ... }
- 15 conversions
  from: describe 'some controller' { }
    to: describe 'some controller', :type => :controller { }
- 13 conversions
  from: describe 'some model' { }
    to: describe 'some model', :type => :model { }
- 8 conversions
  from: obj.unstub(:message)
    to: allow(obj).to receive(:message).and_call_original
- 2 conversions
  from: describe 'some helper' { }
    to: describe 'some helper', :type => :helper { }
- 2 conversions
  from: describe 'some mailer' { }
    to: describe 'some mailer', :type => :mailer { }
- 2 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 1 conversion
  from: describe 'some request' { }
    to: describe 'some request', :type => :request { }

For more details: https://github.com/yujinakayama/transpec#supported-conversions
