### PR TITLE
use maximum instead of max to filter for nil

### DIFF
--- a/app/models/cart_validations.rb
+++ b/app/models/cart_validations.rb
@@ -144,7 +144,7 @@ module CartValidations
     #
     # 0 queries if categories have been eager loaded
     errors = []
-    max_length = model.category.max_checkout_length
+    max_length = model.category.maximum_checkout_length
     if self.duration > max_length
       errors << "#{model.name.titleize} can only be reserved for #{max_length} days"
     end


### PR DESCRIPTION
Resolves a bug where the cart validation returns a 500 internal server error if the category max checkout length is nil (resolves #848)

This does not need to ported to master
