### PR TITLE
#973 Rails Admin authorization

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -9,7 +9,7 @@ RailsAdmin.config do |config|
   # config.current_user_method(&:current_user)
 
   ## == Cancan ==
-  config.authorize_with :cancancan
+  config.authorize_with :cancan
   config.current_user_method &:current_user
 
   ## == PaperTrail ==


### PR DESCRIPTION
Resolves #973, depends on #975 to work properly (rename the ability to `cannot :access, :rails_admin` [here](https://github.com/YaleSTC/reservations/blob/973_access_control/app/models/ability.rb#L12))
