### PR TITLE
[1075] Add jscs and jshint

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,5 @@
+{
+  "preset": "airbnb",
+  "excludeFiles": ["!(app|lib)"],
+  "maxErrors": 50
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+!(app|lib)
+vendor

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,57 @@
+{
+  "maxerr": 50,
+  /*
+  * ENVIRONMENTS
+  * =================
+  */
+
+  // Define globals exposed by modern browsers.
+  "browser": true,
+
+  // Define globals exposed by jQuery.
+  "jquery": true,
+
+  /*
+  * ENFORCING OPTIONS
+  * =================
+  */
+
+  // Force all variable names to use either camelCase style or UPPER_CASE
+  // with underscores.
+  "camelcase": true,
+
+  // Prohibit use of == and != in favor of === and !==.
+  "eqeqeq": true,
+
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Prohibit use of a variable before it is defined.
+  "latedef": true,
+
+  // Enforce line length to 80 characters
+  "maxlen": 80,
+
+  // Require capitalized names for constructor functions.
+  "newcap": true,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "single",
+
+  // Enforce placing 'use strict' at the top function scope
+  "strict": true,
+
+  // Prohibit use of explicitly undeclared variables.
+  "undef": true,
+
+  // Warn when variables are defined but never used.
+  "unused": true,
+
+  /*
+  * RELAXING OPTIONS
+  * =================
+  */
+
+  // Suppress warnings about == null comparisons.
+  "eqnull": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - npm install -g npm
   - echo "$(npm --version) (after npm upgrade)"
   - npm install -g jshint jscs
+  - npm install jshint-stylish
   - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
 
 bundler_args: --without=production staging development
@@ -29,7 +30,7 @@ before_script:
 
 script:
   - jscs .
-  - jshint .
+  - jshint --reporter=node_modules/jshint-stylish/stylish.js .
   - bundle exec rubocop -D
   - bundle exec rake
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,16 @@ env:
       secure: IHUYMK2spxorl9lUeAbAfT6btuP2qRT615bUnEuUDgYrXf9y1CdQprYWJaygou/+6aWmLL0NnxYSpOxi40bHgMKeUQnTjXVbkkqQ1Tml3cMSsjkBrx7CNUygHvDDzCQCEC6m9uZjUKMZAVzVSWlOQhSMKR7MtdsSvMCrKIgA2pM=
 
 before_install:
+  - convert -version
+  - gs -v
+  - npm --version
+  - node --version
+  - npm install -g npm
+  - echo "$(npm --version) (after npm upgrade)"
+  - npm install -g jshint jscs
   - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
+
+bundler_args: --without=production staging development
 
 before_script:
   - cp config/database.travis.yml config/database.yml
@@ -19,8 +28,10 @@ before_script:
   - bundle exec rake db:schema:load
 
 script:
-  - bundle exec rake
+  - jscs .
+  - jshint .
   - bundle exec rubocop -D
+  - bundle exec rake
 
 # From Travis CI Support: This will route jobs to our beta build environment,
 # which has much faster boot times, making it easier to debug via Travis.


### PR DESCRIPTION
Adds and configures the linters [jscs](https://www.npmjs.com/package/jscs) and [jshint](http://jshint.com/). Merging into @orenyk's branch since that seems to make the most sense right now.

Also streamlines `bundle install` since we're now just installing what we need to run tests instead of everything.

NOTE: The Travis build *should* be failing, because both jscs and jshint are failing.