### PR TITLE
1053 decativated status

### DIFF
--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -74,9 +74,13 @@ function renderCalendar(reservations, week_start, max, blackouts) {
       var color = '#aaaaaa';
     } else {
       var val = parseInt($(this).children('.num').children()[0].innerHTML);
-      var red = Math.min(Math.floor(510 - val*510/max),255).toString();
-      var green = Math.min(Math.floor(val*510/max),255).toString();
-      var color = 'rgba(' + red + ',' + green + ',0,0.3)';
+      if (val == 0) {
+        var color = 'rgba(255,0,0,0.3)'
+      } else {
+        var red = Math.min(Math.floor(510 - val*510/max),255).toString();
+        var green = Math.min(Math.floor(val*510/max),255).toString();
+        var color = 'rgba(' + red + ',' + green + ',0,0.3)';
+      }
     }
     $(this).css("background-color",color);
 

--- a/app/controllers/requirements_controller.rb
+++ b/app/controllers/requirements_controller.rb
@@ -49,7 +49,7 @@ class RequirementsController < ApplicationController
 
   def requirement_params
     params.require(:requirement)
-      .permit(:user_id, :user_ids, :description, :equipment_model_id,
-              :equipment_model_ids, :notes, :contact_info, :contact_name)
+      .permit(:user_id, :user_ids, :description, { equipment_model_ids: [] },
+              :equipment_model_id, :notes, :contact_info, :contact_name)
   end
 end

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -13,12 +13,17 @@ class Requirement < ActiveRecord::Base
             :description,
             :contact_name, presence: true
 
+  # rubocop:disable MethodLength
   def self.list_requirement_admins(current_user, equipment_model)
-    req_status = ''
+    req_status = '<ul>'
     met_reqs = (equipment_model.requirements & current_user.requirements)
     outstanding_reqs = equipment_model.requirements - met_reqs
     admin_names = outstanding_reqs.collect(&:contact_name).to_sentence
     admin_contacts = outstanding_reqs.collect(&:contact_info).to_sentence
+    outstanding_reqs.each do |req|
+      req_status += "<li>#{req.description}</li>"
+    end
+    req_status += '</ul>'
     if met_reqs.empty?
       req_status += 'This model requires proper training before it can be '\
         'reserved. '
@@ -30,10 +35,10 @@ class Requirement < ActiveRecord::Base
     end
     # this is currently returning all names, then all email addresses, in one
     # sentence
-    # rubocop:disable UselessAssignment
-    req_status += 'Please contact ' + admin_names + ' at ' + admin_contacts\
+    resp = outstanding_reqs.count > 1 ? ' respectively' : ''
+    req_status += "Please contact #{admin_names}#{resp} at #{admin_contacts}"\
       + ' about becoming certified.'
-    # rubocop:enable UselessAssignment
+    req_status
   end
 
   # This code is all related to creating requirements that have multi-step

--- a/app/views/catalog/_equipment_model_div.html.erb
+++ b/app/views/catalog/_equipment_model_div.html.erb
@@ -41,7 +41,7 @@
       <h3>Qualification Required</h3>
     </div>
     <div class="modal-body">
-      <p><%= Requirement.list_requirement_admins(User.find(cart.reserver_id), equipment_model) %></p>
+      <p><%= Requirement.list_requirement_admins(User.find(cart.reserver_id), equipment_model).html_safe %></p>
     </div>
   </div>
   <% end %>

--- a/app/views/equipment_models/_add_to_cart.html.erb
+++ b/app/views/equipment_models/_add_to_cart.html.erb
@@ -1,27 +1,28 @@
-  <% if @restricted %>
-    <%= link_to "#qualifications_modal",
-      class: 'not-qualified-icon-em',
-      rel: "tooltip",
-      title: 'Not Qualified (click for more info)',
-      :"data-toggle" => 'modal' do %>
-        <span class="fa fa-exclamation-triangle"></span>
-     <% end %>
-     <%= button_tag "Add to Cart", remote: true, class: 'btn btn-primary btn-large disabled' %>
-     <div id="qualifications_modal" class="modal hide fade">
-       <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">×</button>
-          <h3><%= "Qualification Required" %></h3>
-       </div>
-       <div class="modal-body">
-         <p>
-           <%= Requirement.list_requirement_admins(current_user, @equipment_model)%>
-         </p>
-      </div>
+<% if @equipment_model.deleted_at %>
+  <%= button_tag "Deactivated", remote: true, class: 'btn btn-danger btn-large disabled' %>
+<% elsif @restricted %>
+  <%= link_to "#qualifications_modal",
+    class: '',
+    rel: "tooltip",
+    title: 'Not Qualified (click for more info)',
+    :"data-toggle" => 'modal' do %>
+  <%= button_tag "Not Qualified", remote: true, class: 'btn btn-warning btn-large' %>
+  <% end %>
+  <div id="qualifications_modal" class="modal hide fade">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal">×</button>
+      <h3><%= "Qualification Required" %></h3>
     </div>
-   <% else %>
+    <div class="modal-body">
+      <p>
+        <%= Requirement.list_requirement_admins(current_user, @equipment_model).html_safe %>
+      </p>
+    </div>
+  </div>
+<% else %>
 
-     <%= link_to "Add to Cart", {:url => add_to_cart_path(@equipment_model)},
-                                 :href => add_to_cart_path(@equipment_model),
-                                 :method => :put, :remote => true, :class => 'btn btn-primary btn-large' %>
-   <% end %>
+  <%= link_to "Add to Cart", {:url => add_to_cart_path(@equipment_model)},
+                             :href => add_to_cart_path(@equipment_model),
+                             :method => :put, :remote => true, :class => 'btn btn-primary btn-large' %>
+<% end %>
 

--- a/app/views/equipment_models/show.html.erb
+++ b/app/views/equipment_models/show.html.erb
@@ -1,6 +1,5 @@
 <% title @equipment_model.name %>
 <% subtitle @equipment_model.category.name %>
-
 <div class="row em_info">
   <div class="span3">
     <% if @equipment_model.photo.exists? %>

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -32,12 +32,12 @@ describe Requirement, type: :model do
       'have been met.' do
       req_message = 'This model requires proper training before it can be '\
         "reserved. Please contact #{@requirement.contact_name} and "\
-        "#{@another_requirement.contact_name} at "\
+        "#{@another_requirement.contact_name} respectively at "\
         "#{@requirement.contact_info} and "\
         "#{@another_requirement.contact_info} about becoming certified."
       expect(Requirement.list_requirement_admins(@user_with_unmet_requirement,
-                                                 @equipment_model)).to\
-        eq(req_message)
+                                                 @equipment_model)
+            .include?(req_message)).to be_truthy
     end
 
     it 'should return a list of met requirements, followed by unmet '\
@@ -49,7 +49,8 @@ describe Requirement, type: :model do
         "#{@another_requirement.contact_info} about becoming certified."
       expect(Requirement
         .list_requirement_admins(@user_that_meets_some_requirements,
-                                 @equipment_model)).to eq(req_message)
+                                 @equipment_model)
+        .include?(req_message)).to be_truthy
     end
   end
 end


### PR DESCRIPTION
resolves #1053 and adds a couple other things
* when item is deactivated, 'add to cart' button is red and says 'deactivated' to show status of item
* when item is restricted, 'add to cart' button is yellow and says 'not qualified', when clicked the qualification modal comes up
* calendar cells are always red if no items are available. an edge case (0 items in existence, or model is deactivated) would cause them to be green
* fixes bug with requirement strong parameters not working
* adds requirement description to the modal dropdown