### PR TITLE
[v3.4] #1125 broken emails

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -122,8 +122,10 @@ class ReservationsController < ApplicationController
     res = params[:reservation].clone
 
     # adjust dates to match intended input of Month / Day / Year
-    res[:start_date] = Date.strptime(params[:reservation][:start_date],'%m/%d/%Y')
-    res[:due_date] = Date.strptime(params[:reservation][:due_date],'%m/%d/%Y')
+    # this isn't the right way to handle time zones but we've dealt with it in
+    # v4.0.0
+    res[:start_date] = DateTime.strptime(params[:reservation][:start_date],'%m/%d/%Y')
+    res[:due_date] = DateTime.strptime(params[:reservation][:due_date],'%m/%d/%Y')
 
     message = "Successfully edited reservation."
     # update attributes
@@ -161,7 +163,7 @@ class ReservationsController < ApplicationController
         # update attributes for all equipment that is checked off
         r = Reservation.find(reservation_id)
         r.checkout_handler = current_user
-        r.checked_out = Time.now
+        r.checked_out = Time.zone.now
         r.equipment_object_id = reservation_hash[:equipment_object_id]
 
         # Check that checkout procedures have been performed
@@ -246,7 +248,7 @@ class ReservationsController < ApplicationController
       end
 
       r.checkin_handler = current_user
-      r.checked_in = Time.now
+      r.checked_in = Time.zone.now
 
       # Check that check-in procedures have been performed
       incomplete_procedures = check_procedures(r, reservation_hash, :checkin)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -8,8 +8,8 @@ class Cart
   def initialize
     @errors = ActiveModel::Errors.new(self)
     @items = Hash.new()
-    @start_date = Date.today
-    @due_date = Date.tomorrow
+    @start_date = Time.zone.today
+    @due_date = Time.zone.today + 1.day
     @reserver_id = nil
   end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -90,14 +90,14 @@ class Reservation < ActiveRecord::Base
   def status
     if checked_out.nil?
       if approval_status == 'auto' or approval_status == 'approved'
-        due_date >= Date.today ? "reserved" : "missed"
+        due_date >= Time.zone.today ? "reserved" : "missed"
       elsif approval_status
         approval_status
       else
         "?" # ... is this just in case an admin does something absurd in the database?
       end
     elsif checked_in.nil?
-      due_date < Date.today ? "overdue" : "checked out"
+      due_date < Time.zone.today ? "overdue" : "checked out"
     else
       due_date < checked_in.to_date ? "returned overdue" : "returned on time"
     end
@@ -144,7 +144,7 @@ class Reservation < ActiveRecord::Base
     max_renewal_times = self.equipment_model.maximum_renewal_times
 
     max_renewal_days = self.equipment_model.maximum_renewal_days_before_due
-    return ((self.due_date.to_date - Date.today).to_i < max_renewal_days ) &&
+    return ((self.due_date.to_date - Time.zone.today).to_i < max_renewal_days ) &&
       (self.times_renewed < max_renewal_times) && self.equipment_model.maximum_renewal_length > 0
   end
 

--- a/app/models/reservation_scopes.rb
+++ b/app/models/reservation_scopes.rb
@@ -6,31 +6,31 @@ module ReservationScopes
       scope :finalized, lambda { where("approval_status = ? OR approval_status = ?",'auto','approved') }
       scope :not_returned, lambda { where("checked_in IS NULL").finalized }# called in the equipment_model model
       scope :untouched, lambda { where("checked_out IS NULL").not_returned }
-      scope :reserved, lambda { where("due_date >= ?", Time.now.midnight.utc).untouched.recent }
+      scope :reserved, lambda { where("due_date >= ?", Time.zone.today.to_time).untouched.recent }
       scope :checked_out, lambda { where("checked_out IS NOT NULL").not_returned.recent }
       scope :checked_in, lambda { returned }
-      scope :checked_out_today, lambda { where("checked_out >= ? and checked_out <= ?", Date.today.to_datetime, Date.tomorrow.to_datetime).not_returned.recent }
-      scope :checked_out_previous, lambda { where("checked_out < ? and due_date <= ?", Time.now.midnight.utc, Date.tomorrow.midnight.utc).not_returned.recent }
-      scope :overdue, lambda { where("due_date < ?", Time.now.midnight.utc).checked_out }
+      scope :checked_out_today, lambda { where("checked_out >= ? and checked_out <= ?", Time.zone.today.to_time, Time.zone.today.to_time + 1.day).not_returned.recent }
+      scope :checked_out_previous, lambda { where("checked_out < ? and due_date <= ?", Time.zone.today.to_time, Time.zone.today.to_time + 1.day).not_returned.recent }
+      scope :overdue, lambda { where("due_date < ?", Time.zone.today.to_time).checked_out }
       scope :returned, lambda { where("checked_in IS NOT NULL and checked_out IS NOT NULL").recent }
-      scope :returned_overdue, lambda { returned.select { |r| r.due_date.to_date < r.checked_in.to_date } }
+      scope :returned_overdue, lambda { returned.select { |r| r.due_date < r.checked_in } }
       scope :returned_on_time, lambda { where("checked_in <= due_date").returned }
-      scope :missed, lambda { where("due_date < ?", Time.now.midnight.utc).untouched.recent }
-      scope :upcoming, lambda { where("start_date = ?", Time.now.midnight.utc).reserved.user_sort }
-      scope :checkoutable, lambda { where("start_date <= ?", Time.now.midnight.utc).reserved }
+      scope :missed, lambda { where("due_date < ?", Time.zone.today.to_time).untouched.recent }
+      scope :upcoming, lambda { where("start_date > ?", Time.zone.today.to_time).reserved.user_sort }
+      scope :checkoutable, lambda { where("start_date <= ? and due_date < ?", Time.zone.today.to_time, Time.zone.today.to_time).reserved }
       scope :starts_on_days, lambda { |start_date, end_date|  where(start_date: start_date..end_date) }
-      scope :reserved_on_date, lambda { |date|  where("start_date <= ? and due_date >= ?", date.to_time.utc, date.to_time.utc).finalized }
+      scope :reserved_on_date, lambda { |date|  where("start_date <= ? and due_date >= ?", Time.zone.parse(date.to_s), Time.zone.parse(date.to_s)).finalized }
       scope :for_eq_model, lambda { |eq_model| where(equipment_model_id: eq_model.id).finalized }
       scope :active, lambda { not_returned }
       scope :active_or_requested, lambda { where("checked_in IS NULL and approval_status != ?", 'denied').recent }
       scope :notes_unsent, lambda { where(notes_unsent: true) }
-      scope :requested, lambda { where("start_date >= ? and approval_status = ?", Time.now.midnight.utc, 'requested').recent }
+      scope :requested, lambda { where("start_date >= ? and approval_status = ?", Time.zone.today.to_time, 'requested').recent }
       scope :approved_requests, lambda { where("approval_status = ?", 'approved').recent }
       scope :denied_requests, lambda { where("approval_status = ?", 'denied').recent }
-      scope :missed_requests, lambda { where("approval_status = ? and start_date < ?", 'requested', Time.now.midnight.utc).recent }
+      scope :missed_requests, lambda { where("approval_status = ? and start_date < ?", 'requested', Time.zone.today.to_time).recent }
       scope :for_reserver, lambda { |reserver| where(reserver_id: reserver) }
       scope :reserved_in_date_range, lambda { |start_date, end_date| where("start_date <= ? and due_date >= ?", end_date, start_date).finalized }
-      scope :overlaps_with_date, lambda { |date| where("start_date <= ? and due_date >= ?", date.to_datetime, date.to_datetime) }
+      scope :overlaps_with_date, lambda { |date| where("start_date <= ? and due_date >= ?", Time.zone.parse(date.to_s), Time.zone.parse(date.to_s)) }
       scope :has_notes, lambda { where("notes IS NOT NULL") }
     end
   end

--- a/lib/tasks/delete_missed_reservations.rake
+++ b/lib/tasks/delete_missed_reservations.rake
@@ -1,19 +1,19 @@
 desc "Delete missed reservations"
 task :delete_missed_reservations => :environment do
   #get all reservations that ended yesterday and weren't checked out
-  missed_reservations = Reservation.where("checked_out IS NULL and start_date < ?", Time.now.midnight.utc)
+  missed_reservations = Reservation.missed
   Rails.logger.info "Found #{missed_reservations.size} reservations"
-  
+
   if AppConfig.first.send_notifications_for_deleted_missed_reservations
-    missed_reservations.each do |missed_reservation|  
+    missed_reservations.each do |missed_reservation|
       Rails.logger.info "Sending notification for:\n #{missed_reservation.inspect}"
       UserMailer.missed_reservation_deleted_notification(missed_reservation).deliver
     end
   end
-  
+
   if AppConfig.first.delete_missed_reservations
 
-    missed_reservations.each do |missed_reservation|  
+    missed_reservations.each do |missed_reservation|
       Rails.logger.info "Deleting reservation:\n #{missed_reservation.inspect}"
       missed_reservation.destroy
     end

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -126,7 +126,7 @@ describe ReservationsController do
           get :index
           # Cannot compare objects in nested arrays directly
           assigns(:reservations_set).each do |r|
-            expect(@controller.current_user.reservations.upcoming.map(&:id)).to include(r.id)
+            expect(@controller.current_user.reservations.reserved.map(&:id)).to include(r.id)
          end
         end
       end
@@ -305,7 +305,7 @@ describe ReservationsController do
           @valid_cart = FactoryGirl.build(:cart_with_items)
           @req = Proc.new do
             post :create,
-              {reservation: {start_date: Date.today, due_date: Date.tomorrow,
+              {reservation: {start_date: Time.zone.today, due_date: Time.zone.today + 1.day,
                             reserver_id: @user.id}},
               {cart: @valid_cart}
           end
@@ -429,14 +429,14 @@ describe ReservationsController do
         before(:each) do
           put :update, { id: @reservation.id,
             reservation: FactoryGirl.attributes_for(:reservation,
-              start_date: Date.today.strftime('%m/%d/%Y'),
-              due_date: (Date.tomorrow + 3.days).strftime('%m/%d/%Y')),
+              start_date: Time.zone.today.strftime('%m/%d/%Y'),
+              due_date: (Time.zone.today + 4.days).strftime('%m/%d/%Y')),
             equipment_object: ''}
         end
         it 'should update the reservation details' do
           @reservation.reload
-          expect(@reservation.start_date.to_time.utc).to eq(Date.today.to_time.utc)
-          expect(@reservation.due_date.to_time.utc).to eq((Date.tomorrow + 3.days).to_time.utc)
+          expect(@reservation.start_date).to eq(Time.zone.today)
+          expect(@reservation.due_date).to eq(Time.zone.today + 4.days)
         end
         it { should redirect_to(@reservation) }
       end
@@ -446,8 +446,8 @@ describe ReservationsController do
           @new_equipment_object = FactoryGirl.create(:equipment_object, equipment_model: @reservation.equipment_model)
           put :update, { id: @reservation.id,
             reservation: FactoryGirl.attributes_for(:reservation,
-              start_date: Date.today.strftime('%m/%d/%Y'),
-              due_date: Date.tomorrow.strftime('%m/%d/%Y')),
+              start_date: Time.zone.today.strftime('%m/%d/%Y'),
+              due_date: (Time.zone.today + 1.day).strftime('%m/%d/%Y')),
             equipment_object: @new_equipment_object.id }
         end
         it 'should update the object on current reservation' do
@@ -462,8 +462,8 @@ describe ReservationsController do
           request.env["HTTP_REFERER"] = reservation_path(@reservation)
           put :update, { id: @reservation.id,
             reservation: FactoryGirl.attributes_for(:reservation,
-              start_date: Date.today.strftime('%m/%d/%Y'),
-              due_date: Date.yesterday.strftime('%m/%d/%Y')),
+              start_date: Time.zone.today.strftime('%m/%d/%Y'),
+              due_date: (Time.zone.today - 1.day).strftime('%m/%d/%Y')),
             equipment_object: ''}
         end
         include_examples 'cannot access page'

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -2,8 +2,8 @@
 
 FactoryGirl.define do
   factory :reservation do
-    start_date { Date.today }
-    due_date { Date.tomorrow }
+    start_date { Time.zone.today }
+    due_date { Time.zone.today + 1.day }
     reserver
     equipment_model
 
@@ -18,12 +18,12 @@ FactoryGirl.define do
     end
 
     trait :reserved do
-      start_date { Date.today }
-      due_date { Date.tomorrow }
+      start_date { Time.zone.today }
+      due_date { Time.zone.today + 1.day }
     end
 
     trait :checked_out do
-      checked_out { Date.today }
+      checked_out { Time.zone.today }
       checkout_handler
       after(:build) do |res|
         mod = EquipmentModel.find(res.equipment_model)
@@ -32,26 +32,26 @@ FactoryGirl.define do
     end
 
     trait :missed do
-      start_date { Date.yesterday - 1 }
-      due_date { Date.yesterday }
+      start_date { Time.zone.today - 2.days }
+      due_date { Time.zone.today - 1.day }
     end
 
     trait :returned do
-      start_date { Date.yesterday }
-      due_date { Date.today }
-      checked_out { Date.yesterday }
-      checked_in { Date.today }
+      start_date { Time.zone.today - 1.day }
+      due_date { Time.zone.today }
+      checked_out { Time.zone.today - 1.day }
+      checked_in { Time.zone.today }
       checkin_handler
     end
 
     trait :upcoming do
-      start_date { Date.today }
+      start_date { Time.zone.today }
     end
 
     trait :overdue do
-      start_date { Date.yesterday - 1 }
-      due_date { Date.yesterday }
-      checked_out { Date.yesterday - 1 }
+      start_date { Time.zone.today - 2.days }
+      due_date { Time.zone.today - 1.day }
+      checked_out { Time.zone.today - 2.days }
     end
 
     factory :valid_reservation, traits: [:valid]


### PR DESCRIPTION
Resolves #1125 on `release-v3.4`, almost. We've dealt with an issue that claims that reservations were missed even if they weren't, still trying to figure out why overdue check-in e-mails are being sent *after* the reservation has been checked-in.