### PR TITLE
[v3.4] #1185 Fix Banned Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Changelog
 * This file will be updated whenever a new release is put into production.
 * Any problems should be reported via the "report an issue" link in the footer of the application.
 
+### v3.4.9
+*Released on 16 March 2015*
+#### Bug Fixes
+* Banned users can no longer have reservations created for them or equipment checked out to them ([#1185](https://github.com/YaleSTC/reservations/issues/1185)).
+
 ### v3.4.8
 *Released on 26 October 2014*
 #### Bug Fixes

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,9 @@ class UsersController < ApplicationController
   end
 
   def show
+    if @user.role == 'banned' && @user.id != current_user.id
+      flash[:error] = 'Please note that this user is banned.'
+    end
     @user_reservations = @user.reservations
     @all_equipment = Reservation.active.for_reserver(@user)
     @show_equipment = { checked_out:  @user.reservations.checked_out,

--- a/app/models/cart_validations.rb
+++ b/app/models/cart_validations.rb
@@ -11,6 +11,7 @@ module CartValidations
     # if passed with true argument doesn't run validations that should be
     # skipped when validating renewals
     errors = []
+    errors += check_banned
     errors += check_start_date_blackout
     errors += check_due_date_blackout
     errors += check_overdue_reservations unless renew
@@ -28,6 +29,16 @@ module CartValidations
       errors += check_should_be_renewed(user_reservations,model,self.start_date)
     end
     return errors.uniq.reject{ |a| a.blank? }
+  end
+
+  def check_banned
+    errors = []
+    reserver = User.find_by_id(reserver_id)
+    if reserver && reserver.role == 'banned'
+      errors << 'The reserver is banned and cannot reserve additional '\
+        'equipment.'
+    end
+    errors
   end
 
   def check_start_date_blackout
@@ -187,5 +198,4 @@ module CartValidations
     end
     return ["#{user.name} is missing the following certifications: #{unfulfilled_req_text.to_sentence}"]
   end
-
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -13,7 +13,7 @@ class Reservation < ActiveRecord::Base
   validates :equipment_model, :start_date, :due_date, presence: true
   validate :start_date_before_due_date
   validate :matched_object_and_model
-  validate :not_in_past, :available, on: :create
+  validate :not_in_past, :available, :check_banned, on: :create
 
   nilify_blanks only: [:notes]
 
@@ -136,6 +136,9 @@ class Reservation < ActiveRecord::Base
     # determines if a reservation is eligible for renewal, based on how many days before the due
     # date it is and the max number of times one is allowed to renew
     #
+
+    return false if reserver.role == 'banned'
+
     self.times_renewed ||= 0
 
     # you can't renew a checked in reservation, or one without an equipment model

--- a/app/models/reservation_validations.rb
+++ b/app/models/reservation_validations.rb
@@ -39,8 +39,12 @@ module ReservationValidations
   # Does not run on checked out, checked in, overdue, or missed Reservations
   def not_in_past
     if due_date < Date.today || start_date < Date.today
-      errors.add(:base, "Cannot create reservation in the past\n")
+      errors.add(:base, "Cannot create reservation in the past.\n")
     end
   end
 
+  def check_banned
+    return unless reserver.role == 'banned'
+    errors.add(:base, "Reserver cannot be banned.\n")
+  end
 end


### PR DESCRIPTION
Resolves #1185 on `release-v3.4`
- add cart validation for banned reservers
- add reservation validation for banned reservers on create
- add flash message when viewing banned user profile
- prevent viewing of manage / current view for banned users
- prevent checkout of equipment to banned users