### PR TITLE
[1144] navbar preapp

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
   end
 
   def seen_app_configs
-    return if AppConfig.first.viewed || current_user.nil?
+    return if AppConfig.check(:viewed) || current_user.nil?
     if can? :edit, :app_config
       flash[:notice] = 'Since this is your first time viewing the '\
         'application configurations, we recommend that you take some time '\
@@ -125,7 +125,7 @@ class ApplicationController < ActionController::Base
 
   # check to see if the guest user functionality is disabled
   def guests_disabled?
-    AppConfig.first && !AppConfig.first.enable_guests
+    !AppConfig.check(:enable_guests)
   end
 
   # check to see if we should skip authentication; either looks to see if the

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -33,7 +33,7 @@ class ReservationsController < ApplicationController
 
     @filters = [:reserved, :checked_out, :overdue, :returned, :upcoming,
                 :requested, :approved_requests, :denied_requests]
-    @filters << :missed unless AppConfig.first.res_exp_time
+    @filters << :missed unless AppConfig.check(:res_exp_time)
 
     # if filter in session set it
     if session[:filter]
@@ -116,11 +116,11 @@ class ReservationsController < ApplicationController
           flash[:error] = 'Please review the errors below. If uncorrected, '\
             'any reservations with errors will be filed as a request, and '\
             'subject to administrator approval.'
-          if AppConfig.first.request_text.empty?
+          if AppConfig.get(:request_text).empty?
             @request_text = 'Please give a short justification for this '\
               'equipment request.'
           else
-            @request_text = AppConfig.first.request_text
+            @request_text = AppConfig.get(:request_text)
           end
         end
       end
@@ -143,11 +143,11 @@ class ReservationsController < ApplicationController
       flash[:error] = 'Please give a short justification for this '\
         "reservation #{requested ? 'request' : 'override'}"
       @notes_required = true
-      if AppConfig.first.request_text.empty?
+      if AppConfig.get(:request_text).empty?
         @request_text = 'Please give a short justification for this '\
           'equipment request.'
       else
-        @request_text = AppConfig.first.request_text
+        @request_text = AppConfig.get(:request_text)
       end
       render(:new) && return
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,7 @@ class UsersController < ApplicationController
                         past:         @user_reservations.returned,
                         past_overdue: @user_reservations.returned_overdue }
     @show_equipment[:missed] =
-      @user_reservations.missed unless AppConfig.first.res_exp_time
+      @user_reservations.missed unless AppConfig.check(:res_exp_time)
     @has_pending = @user_reservations.requested.count > 0
   end
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -4,26 +4,23 @@ class AdminMailer < ActionMailer::Base
 
   def notes_reservation_notification(notes_reservations_out,
                                      notes_reservations_in)
-    @app_configs = AppConfig.first
     @notes_reservations_out = notes_reservations_out
     @notes_reservations_in = notes_reservations_in
-    mail(to: @app_configs.admin_email,
+    mail(to: AppConfig.get(:admin_email),
          subject: '[Reservations] Notes for '\
            + (Time.zone.today - 1.day).strftime('%m/%d/%y'))
   end
 
   def overdue_checked_in_fine_admin(overdue_checked_in)
     return if overdue_checked_in.equipment_model.late_fee == 0
-    @app_configs = AppConfig.first
     @overdue_checked_in = overdue_checked_in
-    mail(to: @app_configs.admin_email,
+    mail(to: AppConfig.get(:admin_email),
          subject: '[Reservations] Overdue equipment fine')
   end
 
   def request_filed(request)
-    @app_configs = AppConfig.first
     @reservation = request
-    mail(to: @app_configs.admin_email,
+    mail(to: AppConfig.get(:admin_email),
          subject: '[Reservations] Request submitted')
   end
 end

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -1,8 +1,8 @@
 class NotificationsMailer < ActionMailer::Base
   def new_message(message)
     @message = message
-    mail(to: AppConfig.first.contact_link_location,
-         subject: "[#{AppConfig.first.site_title}] #{message.subject}",
+    mail(to: AppConfig.get(:contact_link_location),
+         subject: "[#{AppConfig.get(:site_title)}] #{message.subject}",
          from: @message.email)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,7 +5,7 @@ class UserMailer < ActionMailer::Base
   if AppConfig.first.nil?
     default from: 'no-reply@reservations.app'
   else
-    default from: AppConfig.first.admin_email, cc: AppConfig.first.admin_email
+    default from: AppConfig.get(:admin_email), cc: AppConfig.get(:admin_email)
   end
 
   # checks the status of the current reservation and sends the appropriate email

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,34 +8,34 @@ class Ability
         can :manage, :all
       when 'admin'
         can :manage, :all
-        cannot :renew, Reservation unless AppConfig.first.enable_renewals
+        cannot :renew, Reservation unless AppConfig.check(:enable_renewals)
         cannot :appoint, :superuser
         cannot :access, :rails_admin
         cannot [:destroy, :update], User, role: 'superuser'
       when 'checkout'
         can :manage, Reservation
         cannot :archive, Reservation
-        cannot :renew, Reservation unless AppConfig.first.enable_renewals
+        cannot :renew, Reservation unless AppConfig.check(:enable_renewals)
         cannot :destroy, Reservation do |r|
           !r.checked_out.nil?
         end
-        unless AppConfig.first.checkout_persons_can_edit
+        unless AppConfig.check(:checkout_persons_can_edit)
           cannot :update, Reservation
         end
         can [:read, :update, :find, :autocomplete_user_last_name], User
-        if AppConfig.first.enable_new_users
+        if AppConfig.check(:enable_new_users)
           can [:create, :quick_new, :quick_create], User
         end
         can :read, EquipmentItem
         can :read, EquipmentModel
-        can :override, :reservation_errors if AppConfig.first.override_on_create
-        can :override, :checkout_errors if AppConfig.first.override_at_checkout
+        can :override, :reservation_errors if AppConfig.get(:override_on_create)
+        can :override, :checkout_errors if AppConfig.get(:override_at_checkout)
       when 'normal' || 'checkout'
         can [:update, :show], User, id: user.id
         can :read, EquipmentModel
         can [:read, :create], Reservation, reserver_id: user.id
         can :destroy, Reservation, reserver_id: user.id, checked_out: nil
-        if AppConfig.first.enable_renewals
+        if AppConfig.check(:enable_renewals)
           can :renew, Reservation, reserver_id: user.id
         end
         can :update_cart, :all
@@ -43,11 +43,11 @@ class Ability
         can :view_all_dates, Reservation
       when 'guest'
         # rubocop:disable BlockNesting
-        if AppConfig.first && AppConfig.first.enable_guests
+        if AppConfig.check(:enable_guests)
           can :read, EquipmentModel
           can :empty_cart, :all
           can :update_cart, :all
-          can :create, User if AppConfig.first.enable_new_users
+          can :create, User if AppConfig.check(:enable_new_users)
         end
         # rubocop:enable BlockNesting
       when 'banned'

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -12,4 +12,17 @@ class AppConfig < ActiveRecord::Base
   validates :admin_email,
             format: { with: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i }
   validates :default_per_cat_page, numericality: { only_integer: true }
+
+  def self.check(prop, val = false)
+    # Check the property given in prop
+    # return val (default false) if AppConfig.first is nil
+    ap = AppConfig.first
+    return val unless ap
+    ap.send(prop)
+  end
+
+  def self.get(prop, val = false)
+    # alias for semantics
+    AppConfig.check(prop, val)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,8 +64,7 @@ class User < ActiveRecord::Base
 
   # ------- validations -------- #
   def skip_phone_validation?
-    return true unless AppConfig.first
-    return true unless AppConfig.first.require_phone
+    return true unless AppConfig.check(:require_phone)
     return true if missing_phone
     !@csv_import.nil?
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,7 +9,7 @@
   <div class="row">
     <div class="col-md-offset-2 col-md-10">
       <%= f.button :submit, 'Sign in' %>
-      <% if AppConfig.first.enable_new_users %>
+      <% if AppConfig.check(:enable_new_users) %>
         <%= link_to 'Register', new_user_path, class: 'btn btn-default' %>
       <% end %>
       <%= link_to 'Forgot your password?', new_password_path(resource_name), class: 'btn btn-default' %>

--- a/app/views/reservations/_index_nav.html.erb
+++ b/app/views/reservations/_index_nav.html.erb
@@ -7,7 +7,7 @@
     <%= render partial: 'index_nav_tab', locals: {filter: :requested, text: 'Requested'} %>
     <%= render partial: 'index_nav_tab', locals: {filter: :checked_out, text: 'Checked Out'} %>
     <%= render partial: 'index_nav_tab', locals: {filter: :overdue, text: 'Overdue'} %>
-    <% unless AppConfig.first.res_exp_time %>
+    <% unless AppConfig.check(:res_exp_time) %>
       <%= render partial: 'index_nav_tab', locals: {filter: :missed, text: 'Missed'} %>
     <% end %>
     <%= render partial: 'index_nav_tab', locals: {filter: :returned, text: 'Returned'} %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -22,7 +22,7 @@
   <%= f.input :first_name %>
   <%= f.input :last_name %>
   <%= f.input :nickname %>
-  <% if AppConfig.first.require_phone %>
+  <% if AppConfig.check(:require_phone) %>
     <%= f.input :phone, required: true, hint: 'Format like (555) 555-5555' %>
   <% else %>
     <%= f.input :phone, hint: 'Format like (555) 555-5555' %>


### PR DESCRIPTION
Resolves #1144 as well as introduces some syntactic sugar to avoid this type of error in the future: when accessing/testing appconfig values use `AppConfig.check(:property)` instead of `AppConfig.first.property`