### PR TITLE
[1109] Add rememberable option for password authentication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ActiveRecord::Base
   if ENV['CAS_AUTH']
     devise :cas_authenticatable
   else
-    devise :database_authenticatable, :recoverable
+    devise :database_authenticatable, :recoverable, :rememberable
   end
 
   has_many :reservations, foreign_key: 'reserver_id', dependent: :destroy

--- a/config/initializers/00_devise.rb
+++ b/config/initializers/00_devise.rb
@@ -52,6 +52,22 @@ Devise.setup do |config|
     # Don't put a too small interval or your users won't have the time to
     # change their passwords.
     config.reset_password_within = 6.hours
+
+    # ==> Configuration for :rememberable
+
+    # The time the user will be remembered without asking for credentials
+    # again.
+    # config.remember_for = 2.weeks
+
+    # Invalidates all the remember me tokens when the user signs out.
+    config.expire_all_remember_me_on_sign_out = true
+
+    # If true, extends the user's remember period when remembered via cookie.
+    # config.extend_remember_period = false
+
+    # Options to be passed to the created cookie. For instance, you can set
+    # secure: true in order to force SSL only cookies.
+    # config.rememberable_options = {}
   end
 
   # ==> devise_cas_authenticatable configuration

--- a/db/migrate/20150327012721_add_rememberable_to_users.rb
+++ b/db/migrate/20150327012721_add_rememberable_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberableToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :remember_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150323013431) do
+ActiveRecord::Schema.define(version: 20150327012721) do
 
   create_table "announcements", force: true do |t|
     t.text     "message"
@@ -204,6 +204,7 @@ ActiveRecord::Schema.define(version: 20150323013431) do
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.string   "cas_login"
+    t.datetime "remember_created_at"
   end
 
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree


### PR DESCRIPTION
Resolves #1109
- add devise :rememberable module
- update devise.rb initializer
- add remember_created_at column to users table