### PR TITLE
[237] change cart reservation

### DIFF
--- a/app/assets/javascripts/cart_pause-resume.js
+++ b/app/assets/javascripts/cart_pause-resume.js
@@ -5,8 +5,10 @@ function pause_cart () {
   $('#userModalBtn').addClass('disabled');
   $('#cart_start_date_cart').prop('readonly', true);
   $('#cart_due_date_cart').prop('readonly', true);
+  $('.quantity').prop('readonly',true);
   $('#cart_buttons').children('a').addClass("disabled"); // disable cart buttons
   $('.add_to_cart_box').children('#add_to_cart').addClass("disabled"); // disable add to cart buttons
+  $('#finalize_reservation_btn').addClass("disabled"); // disable finalize button
   $('#cartSpinner').html('<i class="fa fa-circle-o-notch fa-3x fa-spin"></i>'); // toggle cart spinner
 }
 
@@ -17,8 +19,10 @@ function resume_cart () {
   $('#userModalBtn').removeClass('disabled');
   $('#cart_start_date_cart').prop('readonly', false);
   $('#cart_due_date_cart').prop('readonly', false);
+  $('.quantity').prop('readonly', false);
   $('#cart_buttons').children('a').removeClass("disabled"); // disable cart buttons
   $('.add_to_cart_box').children('#add_to_cart').removeClass("disabled"); // enable add to cart buttons
+  $('#finalize_reservation_btn').removeClass("disabled");// enable finalize button
   $('#cartSpinner').html(''); // turn off cart spinner
 }
 // click add to cart button
@@ -30,8 +34,8 @@ $(document).on('click', '#empty_cart_btn', function () {
   pause_cart();
 });
 
-// click remove from cart button
-$(document).on('click', '#remove_button > a', function () {
+// on change for quantity button
+$(document).on('change', '.quantity', function () {
   pause_cart();
 });
 

--- a/app/assets/stylesheets/reservations/_new.css.scss
+++ b/app/assets/stylesheets/reservations/_new.css.scss
@@ -1,3 +1,13 @@
 .warning-icon {
   color: $btn-warning-bg;
 }
+
+.edit-reservation-form {
+  #quantity-col {
+    width: 100px
+  }
+}
+
+.form-errors {
+  font-size: 18px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -170,14 +170,18 @@ class ApplicationController < ActionController::Base
     notices += "\n" unless notices.blank?
 
     # validate
-    errors = cart.validate_all
+    @errors = cart.validate_all
     # don't over-write flash if invalid date was set above
-    flash[:error] ||= notices + "\n" + errors.join("\n")
+    flash[:error] ||= notices + "\n" + @errors.join("\n")
     flash[:notice] = 'Cart updated.'
 
     # reload appropriate divs / exit
     prepare_catalog_index_vars if params[:controller] == 'catalog'
+  end
 
+  # runs update cart and then reloads the javascript for the dates in sidebar
+  def reload_catalog_cart
+    update_cart
     respond_to do |format|
       format.js { render template: 'cart_js/cart_dates_reload' }
       # guys i really don't like how this is rendering a template for js,

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,6 +60,7 @@ class Ability
     if AppConfig.check(:enable_renewals)
       can :renew, Reservation, reserver_id: @user.id
     end
+    can :reload_catalog_cart, :all
     can :update_cart, :all
     can :update_index_dates, Reservation
     can :view_all_dates, Reservation
@@ -71,6 +72,7 @@ class Ability
     return unless AppConfig.check(:enable_guests)
     can :read, EquipmentModel
     can :empty_cart, :all
+    can :reload_catalog_cart, :all
     can :update_cart, :all
     can :create, User if AppConfig.check(:enable_new_users)
     can :hide, Announcement

--- a/app/views/cart_js/reservation_form.js.erb
+++ b/app/views/cart_js/reservation_form.js.erb
@@ -1,0 +1,11 @@
+resume_cart();
+
+<% if @errors.empty? or (can? :override, :reservation_errors) %>
+  $('#confirm-res-form').html('<%= escape_javascript(render :partial => '/reservations/new_reservation') %>');
+  $('.page-header').html('<h1>Confirm Reservation</h1>');
+<% else %>
+  $('#confirm-res-form').html('<%= escape_javascript(render :partial => '/reservations/new_request' ) %>');
+  $('.page-header').html('<h1>Confirm Reservation Request</h1>');
+<% end %>
+
+load_datepicker();

--- a/app/views/reservations/_cart_dates.html.erb
+++ b/app/views/reservations/_cart_dates.html.erb
@@ -1,5 +1,5 @@
 <div id="cart_dates">
-  <%= form_tag url_for(action: 'update_cart'), remote: true, class: 'form-vertical', id: 'cart_form', method: :put do %>
+  <%= form_tag url_for(action: 'reload_catalog_cart', controller: "catalog"), remote: true, class: 'form-vertical', id: 'cart_form', method: :put do %>
 
     <%= hidden_field_tag 'page', params[:page] %>
     <%# to preserve pagination %>

--- a/app/views/reservations/_edit_reservation_form.html.erb
+++ b/app/views/reservations/_edit_reservation_form.html.erb
@@ -1,0 +1,35 @@
+<div class="edit-reservation-form">
+    <% # items in reservation %>
+      <% if cart.items.empty? %>
+        <span id="cart_is_empty">(empty)</span>
+      <% else %>
+        <table id="table_list_items" class="table table-responsive table-striped table-hover">
+          <tr>
+            <thead>
+              <th></th>
+              <th>Items</th>
+              <th id="quantity-col">Quantity</th>
+            </thead>
+          </tr>
+          <% cart.items.each do |model_id, quantity| %>
+            <% # for each item in the cart, list out the quantity and the name %>
+            <tr>
+              <td>
+                <%= link_to EquipmentModel.find(model_id) do %>
+                  <% image_tag (EquipmentModel.find(model_id).photo.exists? ? EquipmentModel.find(model_id).photo.url(:small) : 'no-image.gif') %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to EquipmentModel.find(model_id).name, EquipmentModel.find(model_id) %>
+              </td>
+              <td id="quantity-col">
+                <%= form_tag url_for(controller: 'catalog', action: 'submit_cart_updates_form', id: model_id), remote: true, class: 'form-vertical', id: 'quantity_form', method: :post do %>
+                  <%= number_field_tag("quantity", quantity, class: 'autosubmitme form-control quantity', min: 0, step: 1, id: "quantity_field_#{model_id}") %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      <% end %>
+    <hr>
+</div>

--- a/app/views/reservations/_new_request.html.erb
+++ b/app/views/reservations/_new_request.html.erb
@@ -1,44 +1,56 @@
-<% title "File Reservation Request" %>
-
-<% unless @errors.empty? %>
-  <p>
-    <h3><i class="fa fa-exclamation-triangle warning-icon"></i> Would you like to <%= link_to "return to the Catalog", catalog_path %> to resolve the following error(s)?</h3>
-  </p>
-  <% @errors.each do |msg| %>
-    <ul>
-      <li><%= msg %></li>
-    </ul>
+<% title "Confirm Reservation Request" %>
+<div id="content" class="col-md-9">
+  <% unless @errors.empty? %>
+    <p>
+      <h3><i class="fa fa-exclamation-triangle warning-icon"></i> Would you like to resolve the following error(s)?</h3>
+    </p>
+    <div class ="form-errors">
+      <% @errors.each do |msg| %>
+        <ul>
+          <li><%= msg %></li>
+        </ul>
+      <% end %>
+    </div>
   <% end %>
-<% end %>
-
-<p>
-  <h3>Equipment requested:</h3>
-</p>
-<%= simple_form_for @reservation do |f| %>
   <p>
-    The following equipment will be requested for
-    <%= User.find(cart.reserver_id).name %>
+    <h4>Equipment requested for
+    <%= link_to User.find(cart.reserver_id).name, User.find(cart.reserver_id),
+    target: '_blank' %>
     from
     <%= cart.start_date.to_s(:long) %> to
     <%= cart.due_date.to_s(:long) %>:
+    </h4>
   </p>
-  <p>
-    <ul class="rounded-list">
-      <% cart.items.each do |model_id, quantity| %>
-        <li data-value="<%= quantity %>"><%= link_to EquipmentModel.find(model_id).name, EquipmentModel.find(model_id) %></li>
-      <% end %>
-    </ul>
-  </p>
-
+  <%= render partial: 'reservations/edit_reservation_form' %>
   <div class="well">
     <%= markdown(@request_text) %>
   </div>
-  <div class="form-group text <%= 'error' if @notes_required %>">
-    <%= f.label "Enter your comments here:" %>
-    <%= f.input_field :notes, class: 'form-control', rows: 5 %>
+  <%= simple_form_for @reservation do |f| %>
+    <div class="form-group text <%= 'error' if @notes_required %>">
+      <%= f.label "Enter your comments here:" %>
+      <%= f.input_field :notes, class: 'form-control', rows: 5 %>
+    </div>
+    <div class="form-group">
+      <%= f.button :submit, "Submit Request", id: 'finalize_reservation_btn', data: { confirm: "Are you sure? This request is not finalized and will be subject to approval by an administrator. It will not be available for checkout until and unless approved, and the request may be denied for any reason at the sole discretion of the administrator." } %>
+    </div>
+  <% end %>
+</div>
+<div id="sidebar" class="col-md-3">
+  <div id="sidebarbottom">
+    <div id="cart" class="well">
+      <div id="cartSpinner"></div>
+      <header class="cart-header">
+        <% if cannot? :manage, Reservation %>
+          <h2>My Cart</h2>
+        <% else %>
+          <h2>Cart</h2>
+        <% end %>
+      </header>
+      <%= form_tag url_for(action: 'change_reservation_dates', controller: "catalog"), remote: true, class: 'form-vertical', id: 'dates_form', method: :put do %>
+        <%# allow user to set start/end dates %>
+        <%= render partial: 'reservations/cart_dates' %>
+      <% end %>
+      <br>
+    </div>
   </div>
-  <div class="form-group">
-    <%= f.button :submit, "Submit Request", data: { confirm: "Are you sure? This request is not finalized and will be subject to approval by an administrator. It will not be available for checkout until and unless approved, and the request may be denied for any reason at the sole discretion of the administrator." } %>
-    <%= link_to "Return to Catalog", catalog_path, class: 'btn btn-default' %>
-  </div>
-<% end %>
+</div>

--- a/app/views/reservations/_new_reservation.html.erb
+++ b/app/views/reservations/_new_reservation.html.erb
@@ -1,50 +1,57 @@
-<% title 'Create Reservation' %>
+<% title 'Confirm Reservation' %>
 
-<% unless @errors.empty? %>
-  <p>
-    <h3>
-      <i class="fa fa-exclamation-triangle warning-icon"></i>
-      Please be aware of the following errors:
-    </h3>
-  </p>
-  <% @errors.each do |msg| %>
-    <ul>
-      <li><%= msg %></li>
-    </ul>
+<div id="content" class="col-md-9">
+  <% unless @errors.empty? %>
+    <p>
+      <h3>
+        <i class="fa fa-exclamation-triangle warning-icon"></i>
+        Please be aware of the following errors:
+      </h3>
+    </p>
+    <div class ="form-errors">
+      <% @errors.each do |msg| %>
+        <ul>
+          <li><%= msg %></li>
+        </ul>
+      <% end %>
+    </div>
   <% end %>
-<% end %>
-
-<p>
-  <h3>Equipment being reserved:</h3>
-</p>
-
-<%= simple_form_for @reservation do |f| %>
   <p>
-    The following equipment will be reserved by
+    <h4>Equipment Reserved for
     <%= link_to User.find(cart.reserver_id).name, User.find(cart.reserver_id),
     target: '_blank' %>
     from
     <%= cart.start_date.to_s(:long) %> to
     <%= cart.due_date.to_s(:long) %>:
-
+    </h4>
   </p>
-
-  <p>
-    <ul class="rounded-list">
-      <% cart.items.each do |model_id, quantity| %>
-        <li data-value="<%= quantity %>">
-          <%= link_to EquipmentModel.find(model_id).name, EquipmentModel.find(model_id) %>
-        </li>
+  <%= render partial: 'reservations/edit_reservation_form' %>
+</div>
+<div id="sidebar" class="col-md-3">
+  <div id="sidebarbottom">
+    <div id="cart" class="well">
+      <div id="cartSpinner"></div>
+      <header class="cart-header">
+        <% if cannot? :manage, Reservation %>
+          <h2>My Cart</h2>
+        <% else %>
+          <h2>Cart</h2>
+        <% end %>
+      </header>
+      <%# allow user to set start/end dates %>
+      <%= form_tag url_for(action: 'change_reservation_dates', controller: "catalog"), remote: true, class: 'form-vertical', id: 'dates_form', method: :put do %>
+        <%= render partial: 'reservations/cart_dates' %>
       <% end %>
-    </ul>
-  </p>
-
-  <div class="form-group text<%= ' error' if @notes_required %>">
-    <%= f.label :notes, "#{@errors.blank? ? 'Optional notes' : 'Justification for error override'} for this reservation:" %>
-    <%= f.input_field :notes, class: 'form-control', rows: 5 %>
+    </div>
+    <%= simple_form_for @reservation do |f| %>
+      <div id="cart" class="well">
+        <div id="cartSpinner"></div>
+        <div class="form-group text<%= ' error' if @notes_required %>">
+          <%= f.label :notes, "#{@errors.blank? ? 'Optional notes' : 'Justification for error override'} for this reservation:" %>
+          <%= f.input_field :notes, class: 'form-control', rows: 5 %>
+        </div>
+        <%= f.button :submit, "Finalize Reservation", id: 'finalize_reservation_btn' %>
+      </div>
+    <% end %>
   </div>
-
-  <hr>
-  <%= f.button :submit, "Finalize Reservation" %>
-  <%= link_to "Return to Catalog", catalog_path, class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,5 +1,7 @@
-<% if @errors.empty? or (can? :override, :reservation_errors) %>
-  <%= render :partial => "new_reservation" %>
-<% else %>
-  <%= render :partial => "new_request" %>
-<% end %>
+<div id='confirm-res-form'>
+	<% if @errors.empty? or (can? :override, :reservation_errors) %>
+	  <%= render :partial => "new_reservation" %>
+	<% else %>
+	  <%= render :partial => "new_request" %>
+	<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Reservations::Application.routes.draw do
 
   resources :equipment_models, concerns: :deactivatable do
     collection do
-      put 'update_cart'
+      put 'update_catalog_cart'
       delete 'empty_cart'
     end
     resources :equipment_items

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -209,7 +209,7 @@ describe ApplicationController, type: :controller do
   end
 
   # TODO: This may involve rewriting the method somewhat
-  describe 'PUT update_cart' do
+  describe 'PUT reload_catalog_cart' do
     before(:each) do
       session[:cart] = Cart.new
       session[:cart].reserver_id = @first_user.id
@@ -230,9 +230,10 @@ describe ApplicationController, type: :controller do
         new_start = Time.zone.today + 3.days
         new_end = Time.zone.today + 4.days
 
-        put :update_cart, cart: { start_date_cart: new_start,
-                                  due_date_cart: new_end },
-                          reserver_id: @new_reserver.id
+        put :reload_catalog_cart,
+            cart: { start_date_cart: new_start,
+                    due_date_cart: new_end },
+            reserver_id: @new_reserver.id
 
         expect(session[:cart].start_date).to eq(new_start)
         expect(session[:cart].due_date).to eq(new_end)
@@ -249,7 +250,7 @@ describe ApplicationController, type: :controller do
         new_start = Time.zone.today - 300.days
         new_end = Time.zone.today + 4000.days
 
-        put :update_cart,
+        put :reload_catalog_cart,
             cart: { start_date_cart: new_start.strftime('%m/%d/%Y'),
                     due_date_cart: new_end.strftime('%m/%d/%Y') },
             reserver_id: @new_reserver.id
@@ -260,7 +261,7 @@ describe ApplicationController, type: :controller do
 
     context 'banned reserver' do
       it 'should set the flash' do
-        put :update_cart,
+        put :reload_catalog_cart,
             cart: { start_date_cart: Time.zone.today,
                     due_date_cart: Time.zone.today + 1.day },
             reserver_id: FactoryGirl.create(:banned).id

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -5,7 +5,10 @@ module FeatureHelpers
     @category = FactoryGirl.create(:category)
     @eq_model =
       FactoryGirl.create(:equipment_model, category: @category)
+    @eq_model2 =
+      FactoryGirl.create(:equipment_model, category: @category)
     @eq_item = FactoryGirl.create(:equipment_item, equipment_model: @eq_model)
+    @eq_item2 = FactoryGirl.create(:equipment_item, equipment_model: @eq_model2)
     @admin = FactoryGirl.create(:admin)
     @superuser = FactoryGirl.create(:superuser)
     @checkout_person = FactoryGirl.create(:checkout_person)


### PR DESCRIPTION
Resolves #237
- Redesign & Add form to confirm reservation page
- Allow user to edit cart & dates on confirm reservation page
- Lock cart when changing quantities
- Add submit_cart_updates_form in catalog controller to update cart with changes on confirm reservation page & redirect
- Add change_reservation_dates in catalog controller to update cart dates
- Separate update_cart in application controller into two different methods: performing cart updates and appropriate redirections/js calls
- Add reservation_form.js to dynamically switch between reservations and reservation requests
- Add controller tests & feature tests


(edited to reflect full changes)