### PR TITLE
[1227] Fix broken ToS checkbox handling

### DIFF
--- a/app/assets/javascripts/manage_reservation.js
+++ b/app/assets/javascripts/manage_reservation.js
@@ -37,7 +37,10 @@ function validate_checkin(){
 
   function confirm_checkinout(flag){
     if (flag){
-      if( confirm("Oops! We've noticed one of the following issues:\n\nYou checked off procedures for an item you're not checking in/out.\n\n       or\n\nYou didn't check off all procedures for an item that you are checking in/out.\n\nAre you sure you want to continue?")){
+      if( confirm("Oops! We've noticed one of the following issues:\n\n"+
+        "You didn't check off all procedures for an item your're checking "+
+        "in/out,\n\n\tor\n\nYou didn't select an item for a reservation you "+
+        "checked off procedures for.\n\nAre you sure you want to continue?")){
         (this).submit();
         return false;
       } else {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -312,21 +312,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Checks if params[:terms_of_service_accepted] is necessary; if filled-out,
-  # saves the state of the user; if not filled out and necessary, returns false.
-  # Otherwise, returns true.
-  def check_tos(user)
-    return true if user.terms_of_service_accepted
-
-    user.terms_of_service_accepted = params[:terms_of_service_accepted].present?
-    if user.terms_of_service_accepted
-      user.save
-    else
-      (flash[:error] = 'You must confirm that the user accepts the Terms of '\
-      'Service.') && false
-    end
-  end
-
   private
 
   # modify redirect after signing in


### PR DESCRIPTION
Resolves #1227 on `master`
- add integration specs for ToS checkbox
- fix banned user view handling
- remove check_tos method and only update user if checkout succeeds
- tweak JS confirmation message on manage reservation page