### PR TITLE
[1251] autocomplete ux

### DIFF
--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -6,23 +6,19 @@ ul.ui-autocomplete {
   margin: 0;
   padding: 0;
   border: solid 1px #999;
-  cursor: default; 
+  cursor: pointer;
 }
 
 ul.ui-autocomplete li {
   background-color: #FFF;
   border-top: solid 1px #DDD;
   margin: 0;
-  padding: 0; 
+  padding: 3px !important; 
 }
 
-ul.ui-autocomplete li a {
-  color: #000;
-  display: block;
-  padding: 3px; 
-}
-ul.ui-autocomplete li a.ui-state-hover, ul.ui-autocomplete li a.ui-state-active {
-     background-color: #FFFCB2; 
+ul.ui-autocomplete li.ui-state-focus {
+  color: $component-active-color;
+  background-color: $component-active-bg;
 }
 
 /* end autocomplete */


### PR DESCRIPTION
Resolves #1251 by using bootstrap blue for highlighting as well as changing the pointer cursor for additional visual cue. Also removes some old css that wasn't doing anything
![screenshot - 05212015 - 03 31 07 pm](https://cloud.githubusercontent.com/assets/6618711/7757188/701474fc-ffce-11e4-98ab-7703b331f3ba.png)
