### PR TITLE
[1245] Restrict equipment item note viewing to admins and higher

### DIFF
--- a/app/views/equipment_items/show.html.erb
+++ b/app/views/equipment_items/show.html.erb
@@ -22,7 +22,7 @@
 <%# NOTES %>
 <div class="row">
   <div class="col-md-12">
-    <% unless @equipment_item.notes.blank? %>
+    <% if @equipment_item.notes.present? && (can? :view, :eq_log) %>
       <hr>
       <h3>Notes</h3>
       <div class='notes-container'><%= markdown(@equipment_item.notes) %></div>


### PR DESCRIPTION
Resolves #1245 