### PR TITLE
[1274] Extend query in flag_overdue past yesterday

### DIFF
--- a/lib/tasks/flag_overdue.rake
+++ b/lib/tasks/flag_overdue.rake
@@ -1,6 +1,6 @@
-desc 'Flag reservations due yesterday as overdue'
+desc 'Flag reservations due in the past as overdue'
 task flag_overdue: :environment do
-  new_overdue = Reservation.where('due_date = ?',
+  new_overdue = Reservation.where('due_date <= ?',
                                   Time.zone.today - 1.day).checked_out
   Rails.logger.info "Found #{new_overdue.size} newly overdue reservations"
 

--- a/spec/lib/tasks/flag_rake_spec.rb
+++ b/spec/lib/tasks/flag_rake_spec.rb
@@ -20,6 +20,17 @@ describe 'flag_overdue' do
     expect { subject.invoke }.not_to(
       change { Reservation.find(@res.id).overdue })
   end
+
+  it 'flags past overdue reservations' do
+    old_res = FactoryGirl.build(:overdue_reservation)
+    old_res.assign_attributes(start_date: Time.zone.today - 7.days,
+                              due_date: Time.zone.today - 6.days,
+                              overdue: false)
+    old_res.save!(validate: false)
+
+    expect { subject.invoke }.to \
+      change { Reservation.find(old_res.id).overdue }
+  end
 end
 
 describe 'flag_missed' do


### PR DESCRIPTION
Resolves #1274
- ensures that missed rake tasks don't leave orphaned reservations
- add spec