### PR TITLE
[1243] Add equipment item notes only after reservations save

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -240,10 +240,6 @@ class Reservation < ActiveRecord::Base
       end
     end
     make_notes('Checked in', new_notes, incomplete_procedures, checkin_handler)
-    # update equipment item notes
-    equipment_item.make_reservation_notes('checked in', self,
-                                          checkin_handler, new_notes,
-                                          checked_in)
 
     if checked_in.to_date > due_date
       # equipment was overdue, send an email confirmation
@@ -263,11 +259,6 @@ class Reservation < ActiveRecord::Base
     if checked_in.nil?
       self.checked_in = Time.zone.now
       self.checked_out = Time.zone.now if checked_out.nil?
-      # archive equipment item if checked out
-      if equipment_item
-        equipment_item.make_reservation_notes('archived', self, archiver,
-                                              "#{note}", checked_in)
-      end
       self.notes = notes.to_s + "\n\n### Archived on "\
         "#{checked_in.to_s(:long)} by #{archiver.md_link}\n\n\n#### " \
         "Reason:\n#{note}\n\n#### The checkin and checkout dates may "\
@@ -299,10 +290,6 @@ class Reservation < ActiveRecord::Base
     end
     make_notes('Checked out', new_notes, incomplete_procedures,
                checkout_handler)
-    # update equipment item notes
-    equipment_item.make_reservation_notes('checked out', self,
-                                          checkout_handler, new_notes,
-                                          checked_out)
     self
   end
 

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -1089,6 +1089,32 @@ describe ReservationsController, type: :controller do
       it { expect(response).to be_success }
     end
 
+    context 'with duplicate equipment item selection' do
+      before do
+        request.env['HTTP_REFERER'] = 'where_i_came_from'
+        sign_in @admin
+        @item =
+          FactoryGirl.create :equipment_item,
+                             equipment_model: @reservation.equipment_model
+        FactoryGirl.create :equipment_item,
+                           equipment_model: @reservation.equipment_model
+        @res2 =
+          FactoryGirl.create :valid_reservation,
+                             reserver: @user,
+                             equipment_model: @reservation.equipment_model
+        res_params = { notes: '', equipment_item_id: @item.id }
+        reservations_params = { @reservation.id.to_s => res_params,
+                                @res2.id.to_s => res_params }
+        put :checkout, user_id: @user.id, reservations: reservations_params
+      end
+
+      it { expect(response).to redirect_to 'where_i_came_from' }
+
+      it 'does not update the equipment item history' do
+        expect { @item.reload }.not_to change(@item, :notes)
+      end
+    end
+
     context 'when not all procedures are filled out' do
       before do
         sign_in @admin

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -74,10 +74,14 @@ module FeatureHelpers
   end
 
   def current_user
-    visit root_path
-    click_link 'My Profile'
-    email = find('.page-header h1 small').text
-    User.find_by_email(email)
+    if @current_user
+      @current_user
+    else
+      visit root_path
+      click_link 'My Profile'
+      email = find('.page-header h1 small').text
+      @current_user = User.find_by_email(email)
+    end
   end
 
   def admin_routes


### PR DESCRIPTION
Resolves #1243
- remove `EquipmentItem#make_reservation_notes` calls from `Reservation`
  methods
- only add equipment item notes once the relevant reservation has been
  saved to the database
- add specs for failed checkout / checkin to ensure that equipment item
  notes aren't saved
- improve `current_user` feature spec helper method
- fix N+1 query in the manage reservations view
- add exception handling to `ReservationsController#archive`