### PR TITLE
[1282] Skip auth initializer if using a pre-v4.1.0 DB

### DIFF
--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -1,6 +1,7 @@
 # Check for authentication method and copy data over if necessary (ENV variable
-# to skip if necessary)
-unless ENV['SKIP_AUTH_INIT'] || !User.table_exists? # skip if no users table
+# to skip if necessary, skip if migrating from a pre-v4.1.0 DB or no table)
+unless ENV['SKIP_AUTH_INIT'] || !User.table_exists? ||
+       !User.respond_to?(:username)
   user = User.first
 
   # if we want to use CAS authentication and the username parameter doesn't


### PR DESCRIPTION
Resolves #1282
- automaticaly skip initializer unless `User.respond_to?(:username)`