### PR TITLE
[1284] Add optional admin email on Reservation creation

### DIFF
--- a/app/controllers/app_configs_controller.rb
+++ b/app/controllers/app_configs_controller.rb
@@ -50,6 +50,7 @@ class AppConfigsController < ApplicationController
               :deleted_missed_reservation_email_body, :enable_guests,
               :default_per_cat_page, :terms_of_service, :favicon,
               :checkout_persons_can_edit, :enable_renewals,
-              :override_on_create, :override_at_checkout, :require_phone)
+              :override_on_create, :override_at_checkout, :require_phone,
+              :notify_admin_on_create)
   end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -23,4 +23,10 @@ class AdminMailer < ActionMailer::Base
     mail(to: AppConfig.get(:admin_email),
          subject: '[Reservations] Request submitted')
   end
+
+  def reservation_created_admin(reservation)
+    @reservation = reservation
+    mail(to: AppConfig.get(:admin_email),
+         subject: '[Reservations] Reservation created')
+  end
 end

--- a/app/views/admin_mailer/reservation_created_admin.html.erb
+++ b/app/views/admin_mailer/reservation_created_admin.html.erb
@@ -1,0 +1,10 @@
+<p>A new reservation has been created by
+<%= link_to @reservation.reserver.name, user_url(@reservation.reserver, only_path: false) %></p>
+<ul>
+  <li>Equipment reserved: <%= link_to @reservation.equipment_model.name, equipment_model_url(@reservation.equipment_model, only_path: false) %> </li>
+  <li>Reservation start date: <%= @reservation.start_date.to_s(:long) %></li>
+  <li>Reservation end date: <%= @reservation.due_date.to_s(:long) %></li>
+  <li>Notes: <%= markdown(@reservation.notes) %></li>
+</ul>
+<p>Click <%= link_to "here", reservation_url(@reservation, only_path: false) %> to view this reservation.</p>
+

--- a/app/views/app_configs/_form.erb
+++ b/app/views/app_configs/_form.erb
@@ -36,6 +36,7 @@
     <legend>Unregistered Users</legend>
     <%= f.input :enable_new_users, label: 'Enable User Creation', hint: 'Allow people to create user accounts.' %>
     <%= f.input :enable_guests, label: 'Enable Guest Access', hint: 'Allow people to browse the catalog without signing in.' %>
+    <%= f.input :require_phone, label: 'Are users required to provide a phone number?' %>
   </fieldset>
 
   <fieldset>
@@ -43,14 +44,13 @@
     <%= f.input :checkout_persons_can_edit, label: 'Edit reservations', hint: 'Allow checkout persons to edit reservations.' %>
     <%= f.input :override_on_create, label: 'Override on create', hint: 'Give checkout persons admin-level override capability when creating a reservation. For example, they would be able to create a reservation on a blackout date, or for a period longer than the permitted length for that item.' %>
     <%= f.input :override_at_checkout, label: 'Override at checkout', hint: 'Give checkout persons admin-level override capability when checking out. For example, they would be able to checkout equipment to someone with an overdue reservation.' %>
-    <%= f.input :require_phone, label: 'Are users required to provide a phone number?' %>
   </fieldset>
 
   <fieldset>
-    <legend>Reservation requests</legend><br />
+    <legend>Reservation Creation</legend><br />
+    <%= f.input :notify_admin_on_create, label: 'Notify admin on creation?',hint: 'When enabled, admins will get an e-mail whenever a reservation is created.' %>
     <%= f.input :request_text, label: 'Reservation request text', input_html: {rows: 10},
-      hint: 'This message will be displayed to users who are about to file a reservation request for invalid reservations.
-             You can use markdown in this field' %>
+      hint: 'This message will be displayed to users who are about to file a reservation request for invalid reservations. You can use markdown in this field' %>
     <%= render partial: 'shared/markdown_button' %>
   </fieldset>
 

--- a/db/migrate/20150719040438_add_notify_admin_on_create_to_app_config.rb
+++ b/db/migrate/20150719040438_add_notify_admin_on_create_to_app_config.rb
@@ -1,0 +1,5 @@
+class AddNotifyAdminOnCreateToAppConfig < ActiveRecord::Migration
+  def change
+    add_column :app_configs, :notify_admin_on_create, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150405012126) do
+ActiveRecord::Schema.define(version: 20150719040438) do
 
   create_table "announcements", force: true do |t|
     t.text     "message"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20150405012126) do
     t.boolean  "enable_guests",                                      default: true
     t.boolean  "upcoming_checkout_email_active",                     default: true
     t.text     "upcoming_checkout_email_body"
+    t.boolean  "notify_admin_on_create",                             default: false
   end
 
   create_table "blackouts", force: true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -389,6 +389,7 @@ if AppConfig.count == 0
   ac.overdue_checkin_email_active = false
   ac.site_title = 'Reservations'
   ac.upcoming_checkin_email_active = false
+  ac.notify_admin_on_create = false
   ac.admin_email = 'admin@admin.com'
   ac.department_name = 'Department'
   ac.contact_link_location = 'link'

--- a/lib/tasks/setup_application.rake
+++ b/lib/tasks/setup_application.rake
@@ -160,6 +160,7 @@ namespace :app do
               ac.reservation_confirmation_email_active = false
               ac.overdue_checkin_email_active = false
               ac.send_notifications_for_deleted_missed_reservations = false
+              ac.notify_admin_on_create = false
               ac.upcoming_checkin_email_body = upcoming_checkin_email_body
               ac.upcoming_checkout_email_body = upcoming_checkout_email_body
               ac.deleted_missed_reservation_email_body =

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -397,6 +397,34 @@ describe ReservationsController, type: :controller do
           @req.call
           expect(response).to be_redirect
         end
+
+        context 'with notify_admin_on_create set' do
+          before(:each) do
+            ActionMailer::Base.deliveries.clear
+            AppConfig.first.update_attributes(notify_admin_on_create: true)
+          end
+
+          it 'cc-s the admin on the confirmation email' do
+            @req.call
+            delivered = ActionMailer::Base.deliveries.last
+            expect(delivered).not_to be_nil
+            expect(delivered.subject).to \
+              eq('[Reservations] Reservation created')
+          end
+        end
+
+        context 'without notify_admin_on_create set' do
+          before(:each) do
+            ActionMailer::Base.deliveries.clear
+            AppConfig.first.update_attributes(notify_admin_on_create: false)
+          end
+
+          it 'cc-s the admin on the confirmation email' do
+            @req.call
+            delivered = ActionMailer::Base.deliveries.last
+            expect(delivered).to be_nil
+          end
+        end
       end
 
       context 'with banned reserver' do

--- a/spec/factories/app_configs.rb
+++ b/spec/factories/app_configs.rb
@@ -23,6 +23,7 @@ FactoryGirl.define do
     favicon_updated_at '2013-06-24 14:02:01'
     deleted_missed_reservation_email_body 'MyText'
     send_notifications_for_deleted_missed_reservations true
+    notify_admin_on_create false
     checkout_persons_can_edit false
     request_text ''
   end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -65,4 +65,14 @@ describe AdminMailer, type: :mailer do
       expect(ActionMailer::Base.deliveries.count).to eq(0)
     end
   end
+  describe 'reservation_created_admin' do
+    before do
+      @res = FactoryGirl.create(:valid_reservation)
+      @mail = AdminMailer.reservation_created_admin(@res).deliver
+    end
+    it_behaves_like 'a valid admin email'
+    it 'renders the subject' do
+      expect(@mail.subject).to eq('[Reservations] Reservation created')
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1284
- add `notify_admin_on_create` parameter to app configs
  (default false)
- add `reservation_created_admin` method to AdminMailer
- update e-mail sending logic in Cart
- reordered the app config form a bit
- add tests for all the things