### PR TITLE
[1286] Add kill switch for user e-mails

### DIFF
--- a/app/controllers/app_configs_controller.rb
+++ b/app/controllers/app_configs_controller.rb
@@ -51,6 +51,6 @@ class AppConfigsController < ApplicationController
               :default_per_cat_page, :terms_of_service, :favicon,
               :checkout_persons_can_edit, :enable_renewals,
               :override_on_create, :override_at_checkout, :require_phone,
-              :notify_admin_on_create)
+              :notify_admin_on_create, :disable_user_emails)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -16,6 +16,10 @@ class UserMailer < ActionMailer::Base
                     'returned overdue', 'starts today']
 
   def reservation_status_update(reservation, force = '') # rubocop:disable all
+    if AppConfig.get(:disable_user_emails)
+      Rails.logger.warn 'User e-mails disabled in application settings.'
+      return
+    end
     set_app_config
     @reservation = reservation
 

--- a/app/views/app_configs/_form.erb
+++ b/app/views/app_configs/_form.erb
@@ -83,6 +83,8 @@
       <dt>@tos@</dt><dd>The terms of service</dd>
     </dl>
     <hr />
+    <%= f.input :disable_user_emails, label: 'Disable all user e-mails', hint: 'Prevent Reservations from sending any e-mails to users.' %>
+    <hr />
     <%= f.input :upcoming_checkin_email_active, label: 'Send equipment check-in reminders?',
                 hint: 'When enabled, patrons will get an email reminding them that reservation(s) are due.' %>
     <%= f.input :upcoming_checkin_email_body, input_html: {rows: 10} %>

--- a/db/migrate/20150719050013_add_disable_user_emails_to_app_configs.rb
+++ b/db/migrate/20150719050013_add_disable_user_emails_to_app_configs.rb
@@ -1,0 +1,5 @@
+class AddDisableUserEmailsToAppConfigs < ActiveRecord::Migration
+  def change
+    add_column :app_configs, :disable_user_emails, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150719040438) do
+ActiveRecord::Schema.define(version: 20150719050013) do
 
   create_table "announcements", force: true do |t|
     t.text     "message"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20150719040438) do
     t.boolean  "upcoming_checkout_email_active",                     default: true
     t.text     "upcoming_checkout_email_body"
     t.boolean  "notify_admin_on_create",                             default: false
+    t.boolean  "disable_user_emails",                                default: false
   end
 
   create_table "blackouts", force: true do |t|

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -162,5 +162,11 @@ describe UserMailer, type: :mailer do
       @mail = UserMailer.reservation_status_update(@res).deliver
       expect(@mail).to be_nil
     end
+
+    it "doesn't send at all if disable_user_emails is set" do
+      AppConfig.first.update_attributes(disable_user_emails: true)
+      @mail = UserMailer.reservation_status_update(@res).deliver
+      expect(@mail).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Resolves #1286
- add `disable_user_emails` to app configs
- cause `reservation_status_update` to return if set
- add spec