### PR TITLE
[1285] Add optional cap to reservation late fee

### DIFF
--- a/app/controllers/equipment_models_controller.rb
+++ b/app/controllers/equipment_models_controller.rb
@@ -154,11 +154,11 @@ class EquipmentModelsController < ApplicationController
     # manually add on the procedure elements from params since they
     # don't have fixed hash keys (check to see if they exist first
     # to resolve test failures)
-    params. require(:equipment_model)
+    params.require(:equipment_model)
       .permit(:name, :category_id, :category, :description, :late_fee,
               :replacement_fee, :max_per_user, :document_attributes,
               :deleted_at, :photo, :documentation, :max_renewal_times,
-              :max_renewal_length, :renewal_days_before_due,
+              :max_renewal_length, :renewal_days_before_due, :late_fee_max,
               { associated_equipment_model_ids: [] }, :requirement_ids,
               :requirements, :max_checkout_length)
       .tap do |whitelisted|

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -131,13 +131,18 @@ class Reservation < ActiveRecord::Base
   end
 
   def late_fee
+    return 0 unless overdue
     if checked_in
       end_date = checked_in.to_date
     else
       end_date = Time.zone.today
     end
     fee = equipment_model.late_fee * (end_date - due_date)
-    fee = 0 if fee < 0
+    if fee < 0
+      fee = 0
+    elsif equipment_model.late_fee_max > 0
+      fee = [fee, equipment_model.late_fee_max].min
+    end
     fee
   end
 

--- a/app/views/equipment_models/_form.html.erb
+++ b/app/views/equipment_models/_form.html.erb
@@ -36,6 +36,13 @@
       precision: 2), type: 'number', step: 'any' %>
   <% end %>
 
+  <%= f.input :late_fee_max, wrapper: :horizontal_input_group, hint: 'Maximum possible late fee (set to zero for unlimited).' do %>
+    <%= content_tag :span, "$", class: "input-group-addon" %>
+    <%= f.input_field :late_fee_max,
+      class: 'form-control', value: number_with_precision(f.object.late_fee_max,
+      precision: 2), type: 'number', step: 'any' %>
+  <% end %>
+
   <%= f.input :max_per_user, label: "Maximum per user", hint:
   "Leave blank to default to category value." %>
 

--- a/db/migrate/20150719052612_add_late_fee_max_to_equipment_models.rb
+++ b/db/migrate/20150719052612_add_late_fee_max_to_equipment_models.rb
@@ -1,0 +1,6 @@
+class AddLateFeeMaxToEquipmentModels < ActiveRecord::Migration
+  def change
+    add_column :equipment_models, :late_fee_max, :decimal, precision: 10,
+                                                           scale: 2, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150719050013) do
+ActiveRecord::Schema.define(version: 20150719052612) do
 
   create_table "announcements", force: true do |t|
     t.text     "message"
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 20150719050013) do
     t.boolean  "csv_import",                                          default: false, null: false
     t.integer  "max_checkout_length"
     t.integer  "equipment_items_count",                               default: 0,     null: false
+    t.decimal  "late_fee_max",               precision: 10, scale: 2, default: 0.0
   end
 
   create_table "equipment_models_associated_equipment_models", id: false, force: true do |t|


### PR DESCRIPTION
Resolves #1285
- add `late_fee_max` parameter to Equipment Models
- update `Reservation#late_fee` logic to account for it
- add specs for `Reservation#late_fee`
- make `Reservation#late_fee` return 0 if reservation isn't overdue