### PR TITLE
[1265] Setup script for setting up initial user doesn't echo the typed password

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -107,7 +107,7 @@ end
 
 def prompt_password(user)
   puts 'Temp Password:'
-  user.password = STDIN.gets.chomp
+  user.password = STDIN.noecho(&:gets).chomp
   user.password_confirmation = user.password
   begin
     user.save!

--- a/lib/tasks/setup_application.rake
+++ b/lib/tasks/setup_application.rake
@@ -41,9 +41,9 @@ namespace :app do
         else
           username = email
           puts 'Password:'
-          password = STDIN.gets.chomp
+          password = STDIN.noecho(&:gets).chomp
           puts 'Confirm Password:'
-          password_confirmation = STDIN.gets.chomp
+          password_confirmation = STDIN.noecho(&:gets).chomp
         end
         puts 'Affiliation (i.e. Yale College):'
         affiliation = STDIN.gets.chomp


### PR DESCRIPTION
Resolves #1265

This also makes the same script in db/seeds.rb (prompt_password) not show the typed password too.