### PR TITLE
[1203] Add request expired notifications

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -40,6 +40,9 @@ class UserMailer < ActionMailer::Base
     if @status == 'reserved'
       # we only send emails for reserved reservations if it was a request
       @status = 'request approved'
+    elsif @status == 'denied' &&
+          @reservation.flagged?(:expired)
+      @status = 'request expired'
     end
 
     status_formatted = @status.sub('_', ' ').split.map(&:capitalize) * ' '

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -34,7 +34,8 @@ class Reservation < ActiveRecord::Base
   # query by where('flags & ? > 0', FLAGS[:flag])
   # or where('flags & ? = 0', FLAGS[:flag]) for not flagged
   FLAGS = { request: (1 << 1), broken: (1 << 2), lost: (1 << 3),
-            fined: (1 << 4), missed_email_sent: (1 << 5) }
+            fined: (1 << 4), missed_email_sent: (1 << 5),
+            expired: (1 << 6) }
 
   ## Class methods ##
 
@@ -95,6 +96,8 @@ class Reservation < ActiveRecord::Base
   end
 
   def flagged?(flag)
+    # checks to see if the given flag is set
+    # you must pass the symbol for the flag
     flags & FLAGS[flag] > 0
   end
 

--- a/app/views/user_mailer/_request_expired.html.erb
+++ b/app/views/user_mailer/_request_expired.html.erb
@@ -1,0 +1,3 @@
+<p>Your <%= link_to 'reservation request', reservation_url(@reservation, only_path: false) %> has expired.</p>
+
+<p> You can request the equipment again <%= link_to 'here', equipment_model_url(@reservation.equipment_model, only_path: false) %>.</p>

--- a/lib/tasks/deny_missed_requests.rake
+++ b/lib/tasks/deny_missed_requests.rake
@@ -2,12 +2,16 @@ desc 'Mark missed requests as denied'
 task deny_missed_requests: :environment do
   # get all requests that began yesterday and weren't approved / denied /
   # acted upon
+  # also sends an email to the user
   missed_requests = Reservation.missed_requests
   Rails.logger.info "Found #{missed_requests.size} missed requests."
 
   missed_requests.each do |request|
     Rails.logger.info "Marking as denied:\n #{request.inspect}"
-    request.update_attributes(status: 'denied')
+    request.status = 'denied'
+    request.flag(:expired)
+    request.save!
+    UserMailer.reservation_status_update(request).deliver
   end
 
   Rails.logger.info 'Finished processing missed requests.'

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -76,6 +76,15 @@ describe UserMailer, type: :mailer do
         "[Reservations] #{@res.equipment_model.name} Request Approved")
     end
 
+    it 'sends expired request notifications' do
+      @res.update_attributes(status: 'denied',
+                             flags: (Reservation::FLAGS[:request] |
+                                     Reservation::FLAGS[:expired]))
+      @mail = UserMailer.reservation_status_update(@res).deliver
+      expect(@mail.subject).to eq(
+        "[Reservations] #{@res.equipment_model.name} Request Expired")
+    end
+
     it 'sends reminders to check-out' do
       @res.update_attributes(
         FactoryGirl.attributes_for(:upcoming_reservation))


### PR DESCRIPTION
Resolves #1203
  - Adds new reservation email type 'request expired'
  - deny_missed_requests sends notification emails
  - Adds a new flag 'expired'
  - Spec for deny_missed_requests updated
  - Spec for 'request expired' emails