### PR TITLE
[1345] Move Heroku deployment gems into separate heroku group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,9 @@ end
 group :production do
   gem 'therubyracer', '~> 0.12.1', require: 'v8'
   gem 'party_foul', '~> 1.5.5'
-  # for Heroku
+end
+
+group :heroku do
   gem 'pg', '~> 0.18.1'
   gem 'unicorn', '~> 4.8.3'
   gem 'rack-timeout', '~> 0.2.0'

--- a/app.json
+++ b/app.json
@@ -52,6 +52,10 @@
     "SERVE_STATIC": {
       "description": "whether or not to serve static assets",
       "value": "1"
+    },
+    "RAILS_GROUPS": {
+      "description": "extra groups to install for Heroku",
+      "value": "heroku"
     }
   },
   "addons": [

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require 'rails/all'
 
 # If you have a Gemfile, require the gems listed there, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(:default, Rails.env)
+Bundler.require(*Rails.groups(:default, Rails.env))
 
 module Reservations
   class Application < Rails::Application


### PR DESCRIPTION
Resolves #1345
- fix issue with missing logs
- add extra Gemfile group to app.json
- update Bundler call in application.rb