### PR TITLE
[1383] Make archived reservations accessible [master]

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -35,7 +35,7 @@ class ReservationsController < ApplicationController
     f = (can? :manage, Reservation) ? :upcoming : :reserved
 
     @filters = [:reserved, :checked_out, :overdue, :returned, :returned_overdue,
-                :upcoming, :requested, :approved_requests, :denied]
+                :upcoming, :requested, :approved_requests, :denied, :archived]
     @filters << :missed unless AppConfig.first.res_exp_time
 
     # if filter in session set it

--- a/app/views/reservations/_index_nav.html.erb
+++ b/app/views/reservations/_index_nav.html.erb
@@ -12,6 +12,7 @@
     <% end %>
     <%= render partial: 'index_nav_tab', locals: {filter: :returned, text: 'Returned'} %>
     <%= render partial: 'index_nav_tab', locals: {filter: :returned_overdue, text: 'Returned Overdue'} %>
+    <%= render partial: 'index_nav_tab', locals: {filter: :archived, text: 'Archived'} %>
     <%= render partial: 'index_nav_tab', locals: {filter: :approved_requests, text: 'Approved'} %>
     <%= render partial: 'index_nav_tab', locals: {filter: :denied, text: 'Denied'} %>
   </ul>

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -93,7 +93,7 @@ describe ReservationsController, type: :controller do
 
     before(:all) do
       @filters = [:reserved, :checked_out, :overdue, :missed,
-                  :returned, :upcoming]
+                  :returned, :upcoming, :archived]
     end
 
     context 'when accessed by non-banned user' do

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -77,6 +77,10 @@ FactoryGirl.define do
       end
     end
 
+    trait :archived do
+      status { 'archived' }
+    end
+
     factory :valid_reservation, traits: [:valid]
     factory :checked_out_reservation, traits: [:valid, :checked_out]
     factory :checked_in_reservation, traits: [:valid, :checked_out, :returned]


### PR DESCRIPTION
Resolves #1383 on master
- Add 'archived' tab and filter to the Reservations index
- ~~Display archived Reservations in the 'Past' category on the User profile page~~
- Add archived trait to the Reservations factory
- Update Reservations controller spec with new filter