### PR TITLE
[1339] Adding the ability to hide the announcements for all users [v5.5]

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,6 +31,7 @@ class Ability
         can :override, :reservation_errors if AppConfig.get(:override_on_create)
         can :override, :checkout_errors if AppConfig.get(:override_at_checkout)
         can :view_detailed, EquipmentModel
+        can :hide, Announcement
       when 'normal' || 'checkout'
         can [:update, :show], User, id: user.id
         can :read, EquipmentModel
@@ -43,6 +44,7 @@ class Ability
         can :update_index_dates, Reservation
         can :view_all_dates, Reservation
         can :view_detailed, EquipmentModel
+        can :hide, Announcement
       when 'guest'
         # rubocop:disable BlockNesting
         if AppConfig.check(:enable_guests)
@@ -50,9 +52,11 @@ class Ability
           can :empty_cart, :all
           can :update_cart, :all
           can :create, User if AppConfig.check(:enable_new_users)
+          can :hide, Announcement
         end
         # rubocop:enable BlockNesting
       when 'banned'
+        can :hide, Announcement
         # cannot :create, Reservation
       end
       case user.role

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -130,4 +130,55 @@ describe AnnouncementsController, type: :controller do
       it_behaves_like 'access denied'
     end
   end
+  context 'GET hide as' do
+    shared_examples 'can hide announcement' do
+      before do
+        @announcement = FactoryGirl.create(:announcement)
+        request.env['HTTP_REFERER'] = 'where_i_came_from'
+        get :hide, id: @announcement
+      end
+      it 'should set some cookie values' do
+        name = 'hidden_announcement_ids'
+        jar = request.cookie_jar
+        jar.signed[name] = [@announcement[:id].to_s]
+        expect(response.cookies[name]).to eq(jar[name])
+      end
+    end
+    context 'superuser' do
+      before do
+        sign_in FactoryGirl.create(:superuser)
+      end
+      it_behaves_like 'can hide announcement'
+    end
+    context 'admin' do
+      before do
+        sign_in FactoryGirl.create(:admin)
+      end
+      it_behaves_like 'can hide announcement'
+    end
+    context 'patron' do
+      before do
+        sign_in FactoryGirl.create(:user)
+      end
+      it_behaves_like 'can hide announcement'
+    end
+    context 'checkout person' do
+      before do
+        sign_in FactoryGirl.create(:checkout_person)
+      end
+      it_behaves_like 'can hide announcement'
+    end
+    context 'guest' do
+      before do
+        sign_in FactoryGirl.create(:guest)
+      end
+      it_behaves_like 'can hide announcement'
+    end
+    context 'banned user' do
+      before do
+        sign_in FactoryGirl.create(:banned)
+      end
+      it_behaves_like 'can hide announcement'
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1339 for v5.5
- Change the ability file
- Add a cookie testing spec
- Add shared examples for specs

Reviewed in #1350, merging immediately.