### PR TITLE
[1425] Fix documentation links with relative url root [v5.5]

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,4 +35,13 @@ module ApplicationHelper
     return 'unrestricted' if integer.nil? || integer == Float::INFINITY
     pluralize(integer, 'day')
   end
+
+  def paperclip_full_url(upload)
+    return '#' unless upload.url
+    unless Rails.application.config.action_controller.relative_url_root
+      return upload.url
+    end
+    "/#{Rails.application.config.action_controller.relative_url_root}" \
+      "#{upload.url}"
+  end
 end

--- a/app/views/equipment_models/show.html.erb
+++ b/app/views/equipment_models/show.html.erb
@@ -69,7 +69,7 @@
     <li><a href="#description">Description</a></li>
     <li><a href="#details">Details</a></li>
     <% if @equipment_model.documentation.exists? %>
-      <li><a href="#documenatloction">Documentation</a></li>
+      <li><a href="#documentation">Documentation</a></li>
     <% end %>
     <% if @equipment_model.model_restricted?(cart.reserver_id) %>
       <li><a href="#requirements">Requirements</a></li>
@@ -128,7 +128,8 @@
         <div class="col-md-3">
           <h4>
             <%= (link_to @equipment_model.documentation_file_name,
-                 @equipment_model.documentation.url, target: "_blank") if @equipment_model.documentation.exists? %>
+                         paperclip_full_url(@equipment_model.documentation),
+                         target: "_blank") if @equipment_model.documentation.exists? %>
           </h4>
         </div>
       </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe ApplicationHelper, type: :helper do
+  describe '.paperclip_full_url' do
+    it "when passed an invalid object returns '#'" do
+      bad_obj = double(url: nil)
+
+      expect(paperclip_full_url(bad_obj)).to eq('#')
+    end
+
+    context 'when passed a valid object' do
+      it 'returns the url if no relative root is set' do
+        good_obj = double(url: '/url')
+        Rails.application.config.action_controller.relative_url_root = nil
+
+        expect(paperclip_full_url(good_obj)).to eq(good_obj.url)
+      end
+
+      it 'returns the url prepended by the relative root if set' do
+        good_obj = double(url: '/url')
+        rel_root = 'test'
+        Rails.application.config.action_controller.relative_url_root = rel_root
+
+        expect(paperclip_full_url(good_obj)).to \
+          eq("/#{rel_root}#{good_obj.url}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1425 on release-v5.5
- add helper method in ApplicationHelper
- add specs for said helper method