### PR TITLE
[1426] Fix invalid AdminMailer from address [v5.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 * This file will be updated whenever a new release is put into production.
 * Any problems should be reported via the "report an issue" link in the footer of the application.
 
+## v5.5.2 - 2016-01-18
+### Fixed
+* Resolved an issue where all AdminMailer e-mails were not being delivered ([#1426](https://github.com/YaleSTC/reservations/issues/1426)).
+
 ## v5.5.1 - 2016-01-12
 ### Fixed
 * Fixed issue where most users couldn't hide announcements ([#1339](https://github.com/YaleSTC/reservations/issues/1339)).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,8 @@ Reservations::Application.configure do
   # mailer host: replace 'example.com' with your root url
   # this will allow links in email text to function correctly
   config.action_mailer.default_url_options =
-    { host: "#{ENV['RAILS_HOST_NAME']}#{ENV['RAILS_RELATIVE_URL_ROOT']}" }
+    { host: ENV['RAILS_HOST_NAME'],
+      script_name: ENV['RAILS_RELATIVE_URL_ROOT'] }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)


### PR DESCRIPTION
Resolves #1426 on release-v5.5
- correctly set default_url_options with relative root