### PR TITLE
[1427] Fix typo in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@
 #   RAILS_HOST_NAME - the host name for your application (e.g. example.com),
 #     ensures that e-mail links work
 #   USE_LDAP - whether or not to use LDAP for new user lookup (set to any
-#     value to enable LDAP, requires the next eight parameters)
+#     value to enable LDAP, requires the next nine parameters)
 #   RES_LDAP_HOST - hostname for LDAP lookups
 #   RES_LDAP_PORT - port for LDAP lookups
 #   RES_LDAP_BASE - base for LDAP lookups


### PR DESCRIPTION
Resolves #1427 

I'm merging this in without review as it's not really code.