### PR TITLE
[1424] Properly configure url helpers to use relative root [v5.5]

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,10 @@ Reservations::Application.configure do
 
   # set up PartyFoul
   config.middleware.use('PartyFoul::Middleware') if ENV['PARTY_FOUL_TOKEN']
+
+  # set up routing options for Reports (at a minimum)
+  config.after_initialize do
+    Rails.application.routes.default_url_options =
+      config.action_mailer.default_url_options
+  end
 end


### PR DESCRIPTION
Resolves #1424 on release-v5.5
- extra after_initialize block in config/production.rb to pull settings from action_mailer