### PR TITLE
[1449] Fix cart availability validation [v5.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 * This file will be updated whenever a new release is put into production.
 * Any problems should be reported via the "report an issue" link in the footer of the application.
 
+## v5.5.3 - 2016-01-24
+### Fixed
+* Resolved an issue where checked-out reservations were not being taken into account when validating availability ([#1449](https://github.com/YaleSTC/reservations/issues/1449)).
+
 ## v5.5.2 - 2016-01-18
 ### Fixed
 * Resolved an issue where all AdminMailer e-mails were not being delivered ([#1426](https://github.com/YaleSTC/reservations/issues/1426)).

--- a/app/models/reservation_scopes.rb
+++ b/app/models/reservation_scopes.rb
@@ -73,7 +73,7 @@ module ReservationScopes
       scope :for_reserver, ->(reserver) { where(reserver_id: reserver) }
       scope :reserved_in_date_range, lambda { |start_date, end_date|
         where('start_date <= ? and due_date >= ?', end_date, start_date)
-          .reserved
+          .active
       }
       scope :overlaps_with_date, lambda { |date|
         where('start_date <= ? and due_date >= ?', date, date)


### PR DESCRIPTION
Resolves #1449 for release-v5.5
- ensures that checked-out reservations are also taken into account