### PR TITLE
[1449] Fix cart availability validation [master]

### DIFF
--- a/app/controllers/equipment_models_controller.rb
+++ b/app/controllers/equipment_models_controller.rb
@@ -60,9 +60,9 @@ class EquipmentModelsController < ApplicationController
     @restricted = @equipment_model.model_restricted?(cart.reserver_id)
 
     # For pending reservations table
-    @pending =
-      relevant_reservations.reserved_in_date_range(Time.zone.today,
-                                                   Time.zone.today + 8.days)
+    @pending = relevant_reservations.reserved
+               .overlaps_with_date_range(Time.zone.today,
+                                         Time.zone.today + 8.days)
     # Future reservations using Query object
     @future = @pending.future
   end

--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -15,9 +15,9 @@ class CategoryDecorator < ApplicationDecorator
       # find reservations for models in the category in the next week
       res = 0
       object.equipment_models.each do |em|
-        res += Reservation.for_eq_model(em.id).finalized
-               .reserved_in_date_range(Time.zone.today - 1.day,
-                                       Time.zone.today + 7.days)
+        res += Reservation.for_eq_model(em.id).active
+               .overlaps_with_date_range(Time.zone.today - 1.day,
+                                         Time.zone.today + 7.days)
                .count
       end
       onclick_str = "handleBigDeactivation(this, #{res}, 'category');"

--- a/app/decorators/equipment_model_decorator.rb
+++ b/app/decorators/equipment_model_decorator.rb
@@ -13,9 +13,9 @@ class EquipmentModelDecorator < ApplicationDecorator
   def make_deactivate_btn
     unless object.deleted_at
       # find reservations in the next week
-      res = Reservation.for_eq_model(object.id).finalized
-            .reserved_in_date_range(Time.zone.today - 1.day,
-                                    Time.zone.today + 7.days)
+      res = Reservation.for_eq_model(object.id).active
+            .overlaps_with_date_range(Time.zone.today - 1.day,
+                                      Time.zone.today + 7.days)
             .count
       onclick_str = "handleBigDeactivation(this, #{res}, 'equipment model');"
     end

--- a/app/models/cart_validations.rb
+++ b/app/models/cart_validations.rb
@@ -26,7 +26,7 @@ module CartValidations
 
     source_res =
       Reservation.where(equipment_model_id: items.keys)
-      .reserved_in_date_range(start_date, due_date).all
+      .overlaps_with_date_range(start_date, due_date).active.all
 
     models.each do |model, quantity|
       errors += check_availability(model, quantity, source_res)
@@ -128,8 +128,9 @@ module CartValidations
 
   def check_availability(model = EquipmentModel.find(items.keys.first),
                          quantity = 1,
-                         source_res = Reservation.for_eq_model(id)
-                           .active.all)
+                         source_res =
+                           Reservation.for_eq_model(items.keys.first)
+                             .active.all)
 
     # checks that the model is available for the given quantity given the
     # existence of the source_reservations

--- a/app/models/equipment_model.rb
+++ b/app/models/equipment_model.rb
@@ -191,8 +191,8 @@ class EquipmentModel < ActiveRecord::Base
   def num_available(start_date, due_date)
     # for if you just want the number available, 1 query to get
     # relevant reservations
-    relevant_reservations = Reservation.for_eq_model(id).finalized
-                            .reserved_in_date_range(start_date, due_date)
+    relevant_reservations = Reservation.for_eq_model(id).active
+                            .overlaps_with_date_range(start_date, due_date)
                             .all
     num_available_from_source(start_date, due_date, relevant_reservations)
   end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -79,7 +79,7 @@ class Reservation < ActiveRecord::Base
   scope :ends_on_days, Reservations::EndsOnDaysQuery
   scope :future, Reservations::FutureQuery
   scope :notes_unsent, Reservations::NotesUnsentQuery
-  scope :reserved_in_date_range, Reservations::ReservedInDateRangeQuery
+  scope :overlaps_with_date_range, Reservations::OverlapsWithDateRangeQuery
   scope :reserved_on_date, Reservations::ReservedOnDateQuery
   scope :starts_on_days, Reservations::StartsOnDaysQuery
   scope :upcoming, Reservations::UpcomingQuery

--- a/app/queries/reservations/overlaps_with_date_range_query.rb
+++ b/app/queries/reservations/overlaps_with_date_range_query.rb
@@ -1,9 +1,8 @@
 module Reservations
-  class ReservedInDateRangeQuery < Reservations::ReservationsQueryBase
+  class OverlapsWithDateRangeQuery < Reservations::ReservationsQueryBase
     def call(start_date, end_date)
       @relation
         .where('start_date <= ? and due_date >= ?', end_date, start_date)
-        .reserved
     end
   end
 end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -334,27 +334,30 @@ describe Reservation, type: :model do
     end
   end
 
-  # this all fails - problem w/ available
   context 'with equipment item available problems' do
-    let!(:available_reservation) do
+    before(:each) do
       FactoryGirl.create(:checked_out_reservation,
-                         equipment_model: reservation.equipment_model)
+                         equipment_model: reservation.equipment_model,
+                         start_date: reservation.start_date,
+                         due_date: reservation.due_date,
+                         equipment_item: reservation.equipment_model
+                           .equipment_items.first)
     end
 
-    # it { should_not be_valid } #fails
-    # it 'should not save' do #fails
-    #   reservation.save.should be_falsey
-    #   Reservation.all.size.should == 0
-    # end
-    # it 'cannot be updated' do #fails
-    #   reservation.start_date = Time.zone.today + 1.day
-    #   reservation.save.should be_falsey
-    # end
-    # it 'fails appropriate validations' do # fails
-    #   reservation.should_not be_available
-    #   Reservation.validate_set(reservation.reserver,
-    #                            [] << reservation).should_not == []
-    # end
+    it { is_expected.not_to be_valid }
+    it 'should not save' do
+      expect(reservation.save).to be_falsey
+      expect(Reservation.all.size).to eq(1)
+    end
+    it 'cannot be updated' do
+      reservation.start_date = Time.zone.today + 1.day
+      expect(reservation.save).to be_falsey
+    end
+    it 'fails appropriate validations' do
+      expect(reservation.available).not_to eq([])
+      expect(reservation).not_to be_valid
+    end
+
     it 'passes other custom validations' do
       expect(reservation.start_date_before_due_date).to be_nil
       expect(reservation.not_empty).to be_nil


### PR DESCRIPTION
Resolves #1449 on master
- replace `reserved_in_date_range` with `overlaps_with_date_range` that doesn't take status into account and add `active` where necessary
- add specs for cart availability validation
- fix specs for reservation availability validation