### PR TITLE
[1471] Fix quick new user modal with CAS [v5.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v5.5.4 - 2016-02-02
 ### Fixed
-* The quick new user modal form can now be submitted ([#1421](https://github.com/YaleSTC/reservations/issues/1421)).
+* The quick new user modal form works again ([#1421](https://github.com/YaleSTC/reservations/issues/1421), [#1469](https://github.com/YaleSTC/reservations/issues/1469), [#1471](https://github.com/YaleSTC/reservations/issues/1471)).
 * All URL helpers now use the correct relative root with subdirectory deployment ([#1424](https://github.com/YaleSTC/reservations/issues/1424), [#1465](https://github.com/YaleSTC/reservations/issues/1465)).
 * Fixed the links to Paperclip uploads ([#1425](https://github.com/YaleSTC/reservations/issues/1425)).
 * Uploaded CSVs support extra columns ([#1439](https://github.com/YaleSTC/reservations/issues/1439)).

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,8 @@ class UsersController < ApplicationController
   skip_filter :authenticate_user!, only: [:new, :create]
   before_action :set_user,
                 only: [:show, :edit, :update, :destroy, :ban, :unban]
-  before_action :check_cas_auth, only: [:show, :new, :create, :edit, :update]
+  before_action :check_cas_auth, only: [:show, :new, :create, :quick_create,
+                                        :edit, :update]
 
   include Autocomplete
 
@@ -139,7 +140,12 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     @user.role = 'normal' if user_params[:role].blank?
     @user.view_mode = @user.role
+    # if we're using CAS, set the cas_login correctly
+    @user.cas_login = user_params[:username] if @cas_auth
+
     if @user.save
+      cart.reserver_id = @user.id
+      flash[:notice] = 'Successfully created user.'
       render action: 'create_success'
     else
       render action: 'load_form_errors'


### PR DESCRIPTION
Resolves #1471, resolves #1469 on `release-v5.5`
- controller takes CAS into account
- cart reserver is now set as the new user after creation

Will be merged following a green build, the PR for `master` will be left open for review.