### PR TITLE
[1425] Fix Paperclip URL helper (again) [v5.5]

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,7 +41,7 @@ module ApplicationHelper
     unless Rails.application.config.action_controller.relative_url_root
       return upload.url
     end
-    "/#{Rails.application.config.action_controller.relative_url_root}" \
+    "#{Rails.application.config.action_controller.relative_url_root}" \
       "#{upload.url}"
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -22,7 +22,7 @@ describe ApplicationHelper, type: :helper do
         Rails.application.config.action_controller.relative_url_root = rel_root
 
         expect(paperclip_full_url(good_obj)).to \
-          eq("/#{rel_root}#{good_obj.url}")
+          eq("#{rel_root}#{good_obj.url}")
       end
     end
   end


### PR DESCRIPTION
Resolves #1425 again on release-v5.5; merging after green build, will leave a PR open on `master` for proper review (this has been tested on DEV)