### PR TITLE
[1479] Fix issue with editing overdue reservations [v5.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 * This file will be updated whenever a new release is put into production.
 * Any problems should be reported via the "report an issue" link in the footer of the application.
 
-## v5.5.5 - 2016-02-03
+## v5.5.5 - 2016-02-05
 ### Fixed
+* Updated Rails Admin to allow editing of reservations ([#1449](https://github.com/YaleSTC/reservations/issues/1449#issuecomment-180207219)).
 * The start and end dates of reports can now actually be changed ([#1476](https://github.com/YaleSTC/reservations/issues/1476)).
+* The reservation overdue parameter correctly updates when editing the due date of checked out reservations ([#1479](https://github.com/YaleSTC/reservations/issues/1479)).
 
 ## v5.5.4 - 2016-02-02
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'cancancan', '~> 1.10.1'
 gem 'whenever', '~> 0.9.4'
 
 # administrative panel
-gem 'rails_admin', '~> 0.6.6'
+gem 'rails_admin', '~> 0.8.1'
 
 # ldap integration
 gem 'net-ldap', '~> 0.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    haml (4.0.6)
+    haml (4.0.7)
       tilt
     highline (1.7.2)
     hike (1.2.3)
@@ -269,7 +269,7 @@ GEM
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
-    rails_admin (0.6.6)
+    rails_admin (0.8.1)
       builder (~> 3.1)
       coffee-rails (~> 4.0)
       font-awesome-rails (>= 3.0, < 5)
@@ -455,7 +455,7 @@ DEPENDENCIES
   rails (~> 4.1.9)
   rails4-autocomplete (~> 1.1.1)
   rails_12factor (~> 0.0.3)
-  rails_admin (~> 0.6.6)
+  rails_admin (~> 0.8.1)
   rake (~> 10.4.2)
   rdoc (~> 4.2.0)
   redcarpet (~> 3.2.2)

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -20,6 +20,9 @@ class Reservation < ActiveRecord::Base
   validate :status_final_state
   validate :not_in_past, :available, :check_banned, on: :create
 
+  # correctly update the overdue flag if necessary
+  before_save :update_overdue, if: :checked_out?
+
   nilify_blanks only: [:notes]
 
   # see https://robots.thoughtbot.com/whats-new-in-edge-rails-active-record-enum
@@ -338,13 +341,20 @@ class Reservation < ActiveRecord::Base
             name = 'Due Date'
             old_val = diff[0].to_s(:long)
             new_val = diff[1].to_s(:long)
+            if checked_out?
+              if overdue? && diff[1] > Time.zone.today - 1.day
+                overdue_str = "\nReservation marked as not overdue."
+              elsif !overdue? && diff[1] <= Time.zone.today - 1.day
+                overdue_str = "\nReservation marked as overdue."
+              end
+            end
           when 'equipment_item_id'
             name = 'Item'
             old_val = diff[0] ? EquipmentItem.find(diff[0]).md_link : 'nil'
             new_val = diff[1] ? EquipmentItem.find(diff[1]).md_link : 'nil'
           end
           self.notes += "\n#{name} changed from " + old_val + ' to '\
-            + new_val + '.'
+            + new_val + '.' + overdue_str.to_s
         end
       end
       # rubocop:enable BlockNesting
@@ -398,5 +408,13 @@ class Reservation < ActiveRecord::Base
 
   def md_link
     "[res. \##{id}](#{reservation_url(self, only_path: false)})"
+  end
+
+  private
+
+  def update_overdue
+    return true unless checked_out?
+    self.overdue = due_date <= Time.zone.today - 1.day
+    true # so we don't halt the transaction if it's not overdue
   end
 end

--- a/spec/features/reservations_spec.rb
+++ b/spec/features/reservations_spec.rb
@@ -524,7 +524,7 @@ describe 'Reservations', type: :feature do
       end
 
       context 'cannot renew if the reservation is overdue' do
-        before { @res.update_attributes(overdue: true) }
+        before { @res.update_columns(overdue: true) }
 
         it_behaves_like 'cannot see renew button'
       end

--- a/spec/lib/tasks/flag_rake_spec.rb
+++ b/spec/lib/tasks/flag_rake_spec.rb
@@ -11,7 +11,7 @@ describe 'flag_overdue' do
   it 'flags reservations due yesterday as overdue' do
     @res.update_attributes(
       FactoryGirl.attributes_for(:overdue_reservation))
-    @res.update_attributes(overdue: false)
+    @res.update_columns(overdue: false)
     expect { subject.invoke }.to(
       change { Reservation.find(@res.id).overdue }.from(false).to(true))
   end
@@ -24,9 +24,9 @@ describe 'flag_overdue' do
   it 'flags past overdue reservations' do
     old_res = FactoryGirl.build(:overdue_reservation)
     old_res.assign_attributes(start_date: Time.zone.today - 7.days,
-                              due_date: Time.zone.today - 6.days,
-                              overdue: false)
+                              due_date: Time.zone.today - 6.days)
     old_res.save!(validate: false)
+    old_res.update_columns(overdue: false)
 
     expect { subject.invoke }.to \
       change { Reservation.find(old_res.id).overdue }


### PR DESCRIPTION
Resolves #1479 on release-v5.5
- add `before_save` callback to reservation model to update the `overdue` flag for checked out reservations to match the due date
- add note to `Reservation#update` when toggling the overdue parameter
- update Rails Admin to v0.8.1 to allow editing of reservations

Merging following a green build so we can deploy this in the morning - verified manually on local instance. PR for master will include specs and be properly reviewed.