### PR TITLE
[1479] Fix issue with editing overdue reservations [master]

### DIFF
--- a/app/models/reservation_validations.rb
+++ b/app/models/reservation_validations.rb
@@ -79,7 +79,7 @@ module ReservationValidations
         "today.\n")
       end
     when Reservation.statuses['checked_out']
-      if !checked out
+      if !checked_out
         errors.add(:base, "Checked out reservation must be checked out.\n")
       elsif checked_in
         errors.add(:base, "Checked out reservation must not be checked in.\n")

--- a/lib/tasks/flag_overdue.rake
+++ b/lib/tasks/flag_overdue.rake
@@ -1,7 +1,6 @@
 desc 'Flag reservations due in the past as overdue'
 task flag_overdue: :environment do
-  new_overdue = Reservation.where('due_date <= ?',
-                                  Time.zone.today - 1.day).checked_out
+  new_overdue = Reservation.where('due_date < ?', Time.zone.today).checked_out
   Rails.logger.info "Found #{new_overdue.size} newly overdue reservations"
 
   new_overdue.each do |overdue_reservation|

--- a/spec/features/reservations_spec.rb
+++ b/spec/features/reservations_spec.rb
@@ -524,7 +524,7 @@ describe 'Reservations', type: :feature do
       end
 
       context 'cannot renew if the reservation is overdue' do
-        before { @res.update_attributes(overdue: true) }
+        before { @res.update_columns(overdue: true) }
 
         it_behaves_like 'cannot see renew button'
       end

--- a/spec/lib/tasks/flag_rake_spec.rb
+++ b/spec/lib/tasks/flag_rake_spec.rb
@@ -11,7 +11,7 @@ describe 'flag_overdue' do
   it 'flags reservations due yesterday as overdue' do
     @res.update_attributes(
       FactoryGirl.attributes_for(:overdue_reservation))
-    @res.update_attributes(overdue: false)
+    @res.update_columns(overdue: false)
     expect { subject.invoke }.to(
       change { Reservation.find(@res.id).overdue }.from(false).to(true))
   end
@@ -24,9 +24,9 @@ describe 'flag_overdue' do
   it 'flags past overdue reservations' do
     old_res = FactoryGirl.build(:overdue_reservation)
     old_res.assign_attributes(start_date: Time.zone.today - 7.days,
-                              due_date: Time.zone.today - 6.days,
-                              overdue: false)
+                              due_date: Time.zone.today - 6.days)
     old_res.save!(validate: false)
+    old_res.update_columns(overdue: false)
 
     expect { subject.invoke }.to \
       change { Reservation.find(old_res.id).overdue }


### PR DESCRIPTION
Resolves #1479 on master with specs!
- add before_save callback to reservation model to update the
  overdue flag for checked out reservations to match the due date
- add note to Reservation#update when toggling the overdue parameter
- update Rails Admin to v0.8.1 to allow editing of reservations
- updated broken specs
- added new specs for this behavior