### PR TITLE
[1438] CSV Import Handles CR Line Endings [master]

### DIFF
--- a/lib/csv_import.rb
+++ b/lib/csv_import.rb
@@ -12,8 +12,9 @@ module CsvImport
                            invalid: :replace, undef: :replace, replace: '')
 
     # remove spaces from header line
-    string = string.split "\n"
+    string = string.split(/(\r?\n)|\r/)
     string.first.gsub!(/\s+/, '')
+    string.reject! { |s| /(\r?\n)|\r/.match s }
     string = string.join "\n"
 
     # get rid of any extra columns

--- a/spec/controllers/import_users_controller_spec.rb
+++ b/spec/controllers/import_users_controller_spec.rb
@@ -37,6 +37,9 @@ describe ImportUsersController, type: :controller do
     context 'with extra blank columns' do
       it_behaves_like 'successful upload', 'extra_columns_users.csv'
     end
+    context 'with CR line endings' do
+      it_behaves_like 'successful upload', 'cr_line_endings_users.csv'
+    end
     context "when the isn't csv uploaded" do
       before { post :import }
       it_behaves_like 'failure'

--- a/spec/fixtures/cr_line_endings_users.csv
+++ b/spec/fixtures/cr_line_endings_users.csv
@@ -1,0 +1,1 @@
+username,first_name,last_name,nickname,phone,email,affiliationjd76,Person,One,Unreal,8295555555,whatev@example.com,Library Servicessj2,Person,Two,Imaginary,7395555555,h4ck3r@mail.net,IT Department


### PR DESCRIPTION
Resolves #1438
- Imported CSVs can now contain CR or CFLR line endings