### PR TITLE
[1489] Fix incorrect blackout conflict handling [master]

### DIFF
--- a/app/controllers/blackouts_controller.rb
+++ b/app/controllers/blackouts_controller.rb
@@ -61,14 +61,15 @@ class BlackoutsController < ApplicationController
     end
   end
 
-  def create
+  def create # rubocop:disable MethodLength
     # create a non-recurring blackout
     p = blackout_params
     p[:created_by] = current_user.id
     @blackout = Blackout.new(p)
 
     # check for conflicts
-    res = Reservation.ends_on_days(p[:start_date], p[:end_date])
+    res = Reservation.overlaps_with_date_range(p[:start_date], p[:end_date])
+          .active
 
     # save and exit
     if res.empty? && @blackout.save

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -76,7 +76,6 @@ class Reservation < ActiveRecord::Base
 
   # more complex / task-specific scopes
   scope :checkoutable, Reservations::CheckoutableQuery
-  scope :ends_on_days, Reservations::EndsOnDaysQuery
   scope :future, Reservations::FutureQuery
   scope :notes_unsent, Reservations::NotesUnsentQuery
   scope :overlaps_with_date_range, Reservations::OverlapsWithDateRangeQuery

--- a/app/queries/reservations/ends_on_days_query.rb
+++ b/app/queries/reservations/ends_on_days_query.rb
@@ -1,7 +1,0 @@
-module Reservations
-  class EndsOnDaysQuery < Reservations::ReservationsQueryBase
-    def call(start_date, end_date)
-      @relation.where(due_date: start_date..end_date)
-    end
-  end
-end

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -89,6 +89,7 @@ FactoryGirl.define do
                                                     :returned, :overdue]
     factory :upcoming_reservation, traits: [:valid, :upcoming]
     factory :missed_reservation, traits: [:valid, :missed]
+    factory :archived_reservation, traits: [:valid, :archived]
     factory :request, traits: [:valid, :request]
   end
 end


### PR DESCRIPTION
Resolves #1489 on master
- use `overlaps_with_date_range` instead of `ends_on_days`
- add controller specs for different statuses as well as start and due date checking
- remove useless `ends_on_days` scope / query object
- add `:archived_reservation` factory