### PR TITLE
[1502] direct reservation back error [v5.5]

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -107,7 +107,8 @@ class ReservationsController < ApplicationController
     if cart.items.empty?
       flash[:error] = 'You need to add items to your cart before making a '\
         'reservation.'
-      redirect_to :back
+      redirect_loc = (request.env['HTTP_REFERER'].present? ? :back : root_path)
+      redirect_to redirect_loc
     else
       # error handling
       @errors = cart.validate_all

--- a/spec/features/reservations_spec.rb
+++ b/spec/features/reservations_spec.rb
@@ -545,4 +545,22 @@ describe 'Reservations', type: :feature do
       end
     end
   end
+  context 'accessing /reservation/new path with empty cart' do
+    before(:each) do
+      sign_in_as_user(@admin)
+      empty_cart
+      visit equipment_model_path(@eq_model)
+    end
+    after(:each) { sign_out }
+    it 'handles direct url' do
+      visit new_reservation_path
+      expect(page.current_url).to include(root_path)
+      expect(page).to have_content('Catalog')
+    end
+    it 'handles pressing reserve button' do
+      click_link('Reserve')
+      expect(page.current_url).to include(equipment_models_path)
+      expect(page).to have_content('Description')
+    end
+  end
 end


### PR DESCRIPTION
Resolves 1502.
    Redirects to root_path if request.env['HTTP_REFERER'] is not present.

Added tests to verify this behavior