### PR TITLE
[1502] Redirect correctly  on invalid reservation/new request

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -106,7 +106,8 @@ class ReservationsController < ApplicationController
     if cart.items.empty?
       flash[:error] = 'You need to add items to your cart before making a '\
         'reservation.'
-      redirect_to :back
+      redirect_loc = (request.env['HTTP_REFERER'].present? ? :back : root_path)
+      redirect_to redirect_loc
     else
       # error handling
       @errors = cart.validate_all

--- a/spec/features/reservations_spec.rb
+++ b/spec/features/reservations_spec.rb
@@ -799,4 +799,22 @@ describe 'Reservations', type: :feature do
       it_behaves_like 'can remove an invalid item'
     end
   end
+  context 'accessing /reservation/new path with empty cart' do
+    before(:each) do
+      sign_in_as_user(@admin)
+      empty_cart
+      visit equipment_model_path(@eq_model)
+    end
+    after(:each) { sign_out }
+    it 'handles direct url' do
+      visit new_reservation_path
+      expect(page.current_url).to include(root_path)
+      expect(page).to have_content('Catalog')
+    end
+    it 'handles pressing reserve button' do
+      click_link('Reserve')
+      expect(page.current_url).to include(equipment_models_path)
+      expect(page).to have_content('Description')
+    end
+  end
 end


### PR DESCRIPTION
closes #1502
  - edit reservation_controller new code to redirect to root if
    HTTP_REFERER not present
  - add appropriate tests to spec/features/reservations_spec.rb