### PR TITLE
[1497] Fixes ToS checkbox logic [v5.5]

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -153,10 +153,13 @@ class UsersController < ApplicationController
   end
 
   def edit
+    # refer to the page as Profile if current user, and as User elsewise
+    @edit_title_text = (current_user == @user) ? 'Profile' : 'User'
     @can_edit_username = can? :edit_username, User
   end
 
-  def update # rubocop:disable PerceivedComplexity
+  def update # rubocop:disable CyclomaticComplexity, PerceivedComplexity
+    @edit_title_text = (current_user == @user) ? 'Profile' : 'User'
     par = user_params
     # use :update_with_password when we're not using CAS and you're editing
     # your own profile

--- a/app/views/terms_of_service/_user_accepted.html.erb
+++ b/app/views/terms_of_service/_user_accepted.html.erb
@@ -1,8 +1,8 @@
 <% accepted = @user.terms_of_service_accepted == true %>
 
-<%= f.input :terms_of_service_accepted,
-          input_html: {value: accepted, disabled: (cannot? :manage, Reservation)},
-          label: "#{ (current_user == @user) ? 'I accept' : 'User accepts'} the #{
+<%= f.input :terms_of_service_accepted, # users(admins) cannot accept ToS for other users
+          input_html: {value: accepted, disabled: !(current_user == @user || !current_user)},
+          label: "#{ (current_user == @user || !current_user) ? 'I accept' : 'User accepts'} the #{
                     link_to('Terms of Service', tos_path, target: '_blank')}".html_safe %>
 
 <% if can? :manage, Reservation %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -33,7 +33,7 @@
   <%= hidden_field_tag(:from_cart, false) %>
   <%= hidden_field_tag(:partial_to_render, 'form') %>
 
-  <%= render partial: 'terms_of_service/user_accepted', locals: {f: f} unless action_name == 'new' %>
+  <%= render partial: 'terms_of_service/user_accepted', locals: {f: f} %>
 
   <% if can? :manage, User %>
     <%# TODO: Make this a fancy box %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% title "Edit User" %>
+<% title "Edit #{@edit_title_text}" %>
 
 <div id="edit_form">
   <%= render :partial => 'form' %>

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -40,14 +40,14 @@ describe 'User profile' do
             fill_in 'Current password', with: 'wrongpassword'
             click_button 'Update User'
 
-            expect(page).to have_content('Edit User')
+            expect(page).to have_content('Edit Profile')
             expect(page).to have_content('is invalid')
           end
 
           it 'does not update with blank password' do
             click_button 'Update User'
 
-            expect(page).to have_content('Edit User')
+            expect(page).to have_content('Edit Profile')
             expect(page).to have_content('can\'t be blank')
           end
 
@@ -70,7 +70,7 @@ describe 'User profile' do
               fill_in 'Password confirmation', with: 'wrongpassword'
               click_button 'Update User'
 
-              expect(page).to have_content('Edit User')
+              expect(page).to have_content('Edit Profile')
               expect(page).to have_content('doesn\'t match Password')
             end
           end
@@ -122,14 +122,14 @@ describe 'User profile' do
             fill_in 'Current password', with: 'wrongpassword'
             click_button 'Update User'
 
-            expect(page).to have_content('Edit User')
+            expect(page).to have_content('Edit Profile')
             expect(page).to have_content('is invalid')
           end
 
           it 'does not update with blank password' do
             click_button 'Update User'
 
-            expect(page).to have_content('Edit User')
+            expect(page).to have_content('Edit Profile')
             expect(page).to have_content('can\'t be blank')
           end
 
@@ -152,7 +152,7 @@ describe 'User profile' do
               fill_in 'Password confirmation', with: 'wrongpassword'
               click_button 'Update User'
 
-              expect(page).to have_content('Edit User')
+              expect(page).to have_content('Edit Profile')
               expect(page).to have_content('doesn\'t match Password')
             end
           end


### PR DESCRIPTION
Fixes ToS checkbox logic

Resolves #1497 (on v 5.5)
- Enables ToS checkbox for self-created users
- Disables ToS checkbox for all users(admins) modifying other users
- Now clarifies Editing Profile vs Editing User on Edit Page (and alters relevant tests)