### PR TITLE
[1384] Add optional archival deactivation of equipment

### DIFF
--- a/app/controllers/app_configs_controller.rb
+++ b/app/controllers/app_configs_controller.rb
@@ -51,6 +51,7 @@ class AppConfigsController < ApplicationController
               :default_per_cat_page, :terms_of_service, :favicon,
               :checkout_persons_can_edit, :enable_renewals,
               :override_on_create, :override_at_checkout, :require_phone,
-              :notify_admin_on_create, :disable_user_emails)
+              :notify_admin_on_create, :disable_user_emails,
+              :autodeactivate_on_archive)
   end
 end

--- a/app/controllers/equipment_items_controller.rb
+++ b/app/controllers/equipment_items_controller.rb
@@ -1,4 +1,3 @@
-# rubocop:disable ClassLength
 class EquipmentItemsController < ApplicationController
   load_and_authorize_resource
   decorates_assigned :equipment_item
@@ -71,16 +70,12 @@ class EquipmentItemsController < ApplicationController
     end
   end
 
-  # Deactivate and activate extend controller methods in ApplicationController
-  def deactivate # rubocop:disable MethodLength, AbcSize
+  # extend ApplicationController method; calls destroy twice due to presence of
+  # model method
+  def deactivate
     if params[:deactivation_reason] && !params[:deactivation_cancelled]
-      # update notes and deactivate
-      new_notes = "#### Deactivated at #{Time.zone.now.to_s(:long)} by "\
-        "#{current_user.md_link}\n#{params[:deactivation_reason]}\n\n"\
-        + @equipment_item.notes
-      @equipment_item.update_attributes(
-        deactivation_reason: params[:deactivation_reason],
-        notes: new_notes)
+      @equipment_item.deactivate(user: current_user,
+                                 reason: params[:deactivation_reason])
       # archive current reservation if any
       if @equipment_item.current_reservation
         @equipment_item.current_reservation.archive(
@@ -98,6 +93,7 @@ class EquipmentItemsController < ApplicationController
     end
   end
 
+  # activate extends controller method from ApplicationController
   def activate
     super
     new_notes = "#### Reactivated at #{Time.zone.now.to_s(:long)} by "\

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -502,8 +502,13 @@ class ReservationsController < ApplicationController
           .make_reservation_notes('archived', @reservation, current_user,
                                   params[:archive_note],
                                   @reservation.checked_in)
+        if AppConfig.check(:autodeactivate_on_archive)
+          @reservation.equipment_item.deactivate(user: current_user,
+                                                 reason: params[:archive_note])
+          flash_end = ' The equipment item has been automatically deactivated.'
+        end
       end
-      flash[:notice] = 'Reservation successfully archived.'
+      flash[:notice] = "Reservation successfully archived.#{flash_end}"
     rescue ActiveRecord::RecordNotSaved => e
       flash[:error] = "Archiving your reservation failed: #{e.message}"
     end

--- a/app/models/equipment_item.rb
+++ b/app/models/equipment_item.rb
@@ -107,4 +107,27 @@ class EquipmentItem < ActiveRecord::Base
     self.notes = new_notes.strip
     self
   end
+
+  # Deactivates the equipment item using the #destroy method and
+  # `permanent_records`, while appropriately updating the equipment item notes.
+  #
+  # == Parameters:
+  # options::
+  #   A hash of inputs, required parameters `:user` (any object that responds to
+  #   `md_link`) and `:reason`.
+  #
+  # == Returns:
+  # The equipment item, unchanged if missing inputs or deactivated if passed the
+  # appropriate options.
+  def deactivate(options = {})
+    return unless options[:user] && options[:user].md_link && options[:reason]
+    # update notes
+    new_notes = "#### Deactivated at #{Time.zone.now.to_s(:long)} by "\
+      "#{options[:user].md_link}\n#{options[:reason]}\n\n" + notes
+    self.notes = new_notes
+    self.deactivation_reason = options[:reason]
+    self.save!
+    destroy
+    self
+  end
 end

--- a/app/views/app_configs/_form.erb
+++ b/app/views/app_configs/_form.erb
@@ -47,11 +47,12 @@
   </fieldset>
 
   <fieldset>
-    <legend>Reservation Creation</legend><br />
+    <legend>Reservation Settings</legend><br />
     <%= f.input :notify_admin_on_create, label: 'Notify admin on creation?',hint: 'When enabled, admins will get an e-mail whenever a reservation is created.' %>
     <%= f.input :request_text, label: 'Reservation request text', input_html: {rows: 10},
       hint: 'This message will be displayed to users who are about to file a reservation request for invalid reservations. You can use markdown in this field' %>
     <%= render partial: 'shared/markdown_button' %>
+    <%= f.input :autodeactivate_on_archive, label: 'Autodeactivate equipment after archiving?',hint: 'When enabled, the equipment item assigned to a reservation will be automatically deactivated when that reservation is archived.' %>
   </fieldset>
 
   <fieldset>

--- a/db/migrate/20160311070200_add_autodeactivate_on_archive_to_app_config.rb
+++ b/db/migrate/20160311070200_add_autodeactivate_on_archive_to_app_config.rb
@@ -1,0 +1,5 @@
+class AddAutodeactivateOnArchiveToAppConfig < ActiveRecord::Migration
+  def change
+    add_column :app_configs, :autodeactivate_on_archive, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150719052612) do
+ActiveRecord::Schema.define(version: 20160311070200) do
 
   create_table "announcements", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20150719052612) do
     t.text     "upcoming_checkout_email_body",                       limit: 65535
     t.boolean  "notify_admin_on_create",                                           default: false
     t.boolean  "disable_user_emails",                                              default: false
+    t.boolean  "autodeactivate_on_archive",                                        default: false
   end
 
   create_table "blackouts", force: :cascade do |t|

--- a/spec/controllers/equipment_items_controller_spec.rb
+++ b/spec/controllers/equipment_items_controller_spec.rb
@@ -293,6 +293,7 @@ describe EquipmentItemsController, type: :controller do
       end
       it { expect(response).to be_redirect }
       it { expect(item.deactivation_reason).to eq('Because I can') }
+      it { expect(item.deleted_at).not_to be_nil }
       it 'should change the notes' do
         new_item = FactoryGirl.create(:equipment_item)
         put :deactivate, id: new_item, deactivation_reason: 'reason'

--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -1532,6 +1532,23 @@ describe ReservationsController, type: :controller do
             expect { @reservation.reload }.not_to change { @reservation.notes }
           end
         end
+
+        context 'when auto-deactivate is enabled' do
+          before(:each) do
+            AppConfig.first.update_attributes(autodeactivate_on_archive: true)
+            put :archive, id: @reservation.id, archive_note: 'Because I can'
+          end
+          after(:each) do
+            AppConfig.first.update_attributes(autodeactivate_on_archive: false)
+          end
+
+          it 'should deactivate the equipment item' do
+            ei = @reservation.equipment_item.reload
+            expect(ei.deleted_at).not_to be_nil
+            expect(ei.deactivation_reason).to \
+              include('Because I can')
+          end
+        end
       end
 
       context 'when accessed by checkout person' do

--- a/spec/features/reservations_archive_spec.rb
+++ b/spec/features/reservations_archive_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe 'Reservations archiving', type: :feature do
+  before(:each) do
+    @res = FactoryGirl.create(:valid_reservation)
+  end
+
+  shared_examples_for 'cannot see archive button' do
+    it do
+      visit reservation_path(@res)
+      expect(page).not_to have_link('Archive Reservation')
+    end
+  end
+
+  shared_examples_for 'can archive reservation' do
+    before { visit reservation_path(@res) }
+    it 'can see button' do
+      expect(page).to have_link('Archive Reservation')
+    end
+
+    it '', js: true do
+      accept_prompt(with: 'reason') { click_link 'Archive Reservation' }
+      expect(@res.reload.checked_out).not_to be_nil
+      expect(@res.reload.checked_in).not_to be_nil
+      expect(@res.reload.notes).to include('Archived')
+    end
+  end
+
+  context 'as patron' do
+    before { sign_in_as_user @user }
+    after { sign_out }
+    it_behaves_like 'cannot see archive button'
+  end
+
+  context 'as checkout person' do
+    before { sign_in_as_user @checkout_person }
+    after { sign_out }
+    it_behaves_like 'cannot see archive button'
+  end
+
+  context 'as admin' do
+    before { sign_in_as_user @admin }
+    after { sign_out }
+    it_behaves_like 'can archive reservation'
+
+    context 'with equipment item' do
+      before do
+        @ei = FactoryGirl.create(:equipment_item,
+                                 equipment_model: @res.equipment_model)
+        @res.checkout(@ei.id, @admin, [], '').save
+      end
+
+      it_behaves_like 'can archive reservation'
+
+      context 'with auto-deactivate enabled' do
+        before do
+          @app_config.update_attributes(autodeactivate_on_archive: true)
+        end
+        after do
+          @app_config.update_attributes(autodeactivate_on_archive: false)
+        end
+
+        it 'autodeactivates the equipment item', js: true do
+          visit reservation_path(@res)
+
+          accept_prompt(with: 'reason') { click_link 'Archive Reservation' }
+          expect(@res.reload.checked_in).not_to be_nil
+          expect(@ei.reload.deleted_at).not_to be_nil
+          expect(@ei.reload.deactivation_reason).to include('reason')
+          expect(page).to have_content 'has been automatically deactivated'
+        end
+      end
+
+      context 'without auto-deactivate enabled', js: true do
+        before do
+          @app_config.update_attributes(autodeactivate_on_archive: false)
+        end
+        after { @app_config.update_attributes(autodeactivate_on_archive: true) }
+
+        it 'does not autodeactivate the equipment item' do
+          visit reservation_path(@res)
+
+          accept_prompt(with: 'reason') { click_link 'Archive Reservation' }
+          expect(@res.reload.checked_in).not_to be_nil
+          expect(@ei.reload.deleted_at).to be_nil
+          expect(@ei.reload.deactivation_reason).to be_nil
+          expect(page).not_to have_content 'has been deactivated'
+        end
+      end
+
+      context 'if checked in' do
+        before { @res.checkin(@admin, [], '').save }
+
+        it_behaves_like 'cannot see archive button'
+      end
+    end
+  end
+end

--- a/spec/models/equipment_item_spec.rb
+++ b/spec/models/equipment_item_spec.rb
@@ -119,5 +119,42 @@ describe EquipmentItem, type: :model do
     end
   end
 
+  describe '#deactivate' do
+    before do
+      @ei = FactoryGirl.build(:equipment_item)
+      @user = FactoryGirl.build(:admin)
+    end
+
+    context 'with user and notes' do
+      before { @ei.deactivate(user: @user, reason: 'reason') }
+
+      it 'prepends to the notes' do
+        expect(@ei.notes).to include('reason')
+        expect(@ei.notes).to include(@user.md_link)
+      end
+      it 'sets deleted_at' do
+        expect(@ei.deleted_at).not_to be_nil
+      end
+    end
+
+    context 'without user' do
+      it 'does nothing' do
+        expect { @ei.deactivate(reason: 'reason') }.not_to change { @ei }
+      end
+    end
+
+    context 'without notes' do
+      it 'does nothing' do
+        expect { @ei.deactivate(user: @user) }.not_to change { @ei }
+      end
+    end
+
+    context 'without parameters' do
+      it 'does nothing' do
+        expect { @ei.deactivate }.not_to change { @ei }
+      end
+    end
+  end
+
   it_behaves_like 'linkable'
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,6 +1,7 @@
 module FeatureHelpers
   # make sure we have a working app
   def app_setup
+    AppConfig.delete_all
     @app_config = FactoryGirl.create(:app_config)
     @category = FactoryGirl.create(:category)
     @eq_model =


### PR DESCRIPTION
Resolves #1384
- add `autodeactivate_on_archive` parameter to `AppConfig`
- move equipment item deactivation to a model method
- tweak `ReservationsController#archive` method to implement auto-deactivation
- add feature specs for reservation archiving
- add model specs for `EquipmentItem#deactivate`
- add controller specs for `ReservationsController#archive` with auto-deactivation
- `FeatureHelpers#app_setup` now deletes any pre-existing `AppConfigs`