### PR TITLE
[1524] Resolve issues with contact form [master]

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -1,7 +1,7 @@
 class NotificationsMailer < ActionMailer::Base
   def new_message(message)
     @message = message
-    mail(to: AppConfig.get(:contact_link_location),
+    mail(to: AppConfig.contact_email,
          subject: "[#{AppConfig.get(:site_title)}] #{message.subject}",
          from: @message.email)
   end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -10,6 +10,10 @@ class AppConfig < ActiveRecord::Base
   validates :site_title,   presence: true,
                            length: { maximum: 20 }
   validates :admin_email,
+            presence: true,
+            format: { with: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i }
+  validates :contact_link_location,
+            allow_blank: true,
             format: { with: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i }
   validates :default_per_cat_page, numericality: { only_integer: true }
 
@@ -23,6 +27,17 @@ class AppConfig < ActiveRecord::Base
 
   def self.get(prop, val = false)
     # alias for semantics
-    AppConfig.check(prop, val)
+    check(prop, val)
+  end
+
+  # Returns the to e-mail for contact form submissions, defaulting to the admin
+  # e-mail address if no separate address is specified
+  def self.contact_email
+    contact_email = get(:contact_link_location, nil)
+    if contact_email.nil? || contact_email.empty?
+      get(:admin_email, nil)
+    else
+      contact_email
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -393,7 +393,7 @@ if AppConfig.count == 0
   ac.notify_admin_on_create = false
   ac.admin_email = 'admin@admin.com'
   ac.department_name = 'Department'
-  ac.contact_link_location = 'link'
+  ac.contact_link_location = 'contact@admin.com'
   ac.home_link_text = 'home_link'
   ac.home_link_location = 'Canada'
   ac.deleted_missed_reservation_email_body = DELETED_MISSED_RES_EMAIL

--- a/lib/tasks/setup_application.rake
+++ b/lib/tasks/setup_application.rake
@@ -144,11 +144,7 @@ namespace :app do
         home_link_location = STDIN.gets.chomp
         puts 'Contact Email (this email address will receive contact form '\
           'submissions). Leave blank to default to the admin e-mail.'
-        if STDIN.gets.chomp.empty?
-          contact_link_location = admin_email
-        else
-          contact_link_location = STDIN.gets.chomp
-        end
+        contact_link_location = STDIN.gets.chomp unless STDIN.gets.chomp.empty?
 
         ActiveRecord::Base.transaction do
           begin

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -46,6 +46,29 @@ describe ContactController, type: :controller do
       end
     end
   end
+  context 'with contact e-mail set' do
+    before do
+      AppConfig.first
+        .update_attributes(contact_link_location: 'contact@example.com')
+      post :create, message: FactoryGirl.attributes_for(:message)
+    end
+
+    it 'sends the message to the contact address' do
+      expect(ActionMailer::Base.deliveries.last.to).to\
+        include('contact@example.com')
+    end
+  end
+  context 'with contact e-mail not set' do
+    before do
+      AppConfig.first.update_attributes(contact_link_location: '')
+      post :create, message: FactoryGirl.attributes_for(:message)
+    end
+
+    it 'sends the message to the admin address' do
+      expect(ActionMailer::Base.deliveries.last.to).to\
+        include(AppConfig.first.admin_email)
+    end
+  end
   after(:all) do
     @app_config.destroy
   end

--- a/spec/factories/app_configs.rb
+++ b/spec/factories/app_configs.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     site_title 'Reservations Specs'
     admin_email 'my@email.com'
     department_name 'MyString'
-    contact_link_location 'MyString'
+    contact_link_location 'contact@email.com'
     home_link_text 'MyString'
     home_link_location 'MyString'
     default_per_cat_page 1

--- a/spec/models/app_config_spec.rb
+++ b/spec/models/app_config_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe AppConfig, type: :model do
-  before(:each) do
-    @ac = FactoryGirl.build(:app_config)
-  end
+  before(:all) { AppConfig.delete_all }
+  before(:each) { @ac = FactoryGirl.build(:app_config) }
+
   it 'has a working factory' do
     expect(@ac.save).to be_truthy
   end
@@ -28,6 +28,13 @@ describe AppConfig, type: :model do
     @ac.admin_email = 'ana@yale.edu'
     expect(@ac).to be_valid
   end
+  it "shouldn't have an invalid contact e-mail" do
+    emails = ['ana@com', 'anda@pres,com']
+    emails.each do |invalid|
+      @ac.contact_link_location = invalid
+      expect(@ac).not_to be_valid
+    end
+  end
   # it "has an attachment that could serve as favicon" do
   #   @ac.favicon_file_name = "icon.ico"
   #   @ac.should be_valid
@@ -43,5 +50,25 @@ describe AppConfig, type: :model do
       expect(@ac).not_to be_valid
     end
     @ac.favicon_content_type = 'image/vnd.microsoft.icon'
+  end
+
+  context '.contact_email' do
+    it 'returns the contact e-mail if it is set' do
+      @ac.contact_link_location = 'contact@example.com'
+      @ac.save
+
+      expect(AppConfig.contact_email).to eq('contact@example.com')
+
+      AppConfig.delete_all
+    end
+
+    it 'returns the admin e-mail if no contact e-mail is set' do
+      @ac.contact_link_location = ''
+      @ac.save
+
+      expect(AppConfig.contact_email).to eq(AppConfig.check(:admin_email))
+
+      AppConfig.delete_all
+    end
   end
 end


### PR DESCRIPTION
Resolves #1524 on `master`
- add `AppConfig.contact_email` to correctly default to admin e-mail when no contact e-mail is set
- add validations for `AppConfig.contact_link_location` to ensure it is a valid e-mail if it's not blank
- update seed and application setup script to assign valid e-mails to `contact_link_location` by default, as well as update factories
- add specs