### PR TITLE
[1532] res show date align

### DIFF
--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -90,10 +90,10 @@
               <div id="date_range" class="tab-pane active">
                 <div id="dates_headings" class="row">
                   <div class="col-md-6">
-                    <p><h4>Start Date</h4></p>
+                    <h4>Start Date</h4>
                   </div>
                   <div class="col-md-6">
-                    <p><h4 class="pull-right">Due Date</h4></p>
+                    <h4 class="pull-right">Due Date</h4>
                   </div>
                 </div>
                 <div class="row">
@@ -116,10 +116,10 @@
 
                 <div id="res_dates" class="row">
                   <div class="col-md-6">
-                    <p><h4><%= @reservation.start_date.strftime("%a, %b %d, %Y") %></h4></p>
+                    <h4><%= @reservation.start_date.strftime("%a, %b %d, %Y") %></h4>
                   </div>
                   <div class="col-md-6">
-                    <p><h4 class="pull-right"><%= @reservation.due_date.strftime("%a, %b %d, %Y") %></h4></p>
+                    <h4 class="pull-right"><%= @reservation.due_date.strftime("%a, %b %d, %Y") %></h4>
                   </div>
                 </div>
 


### PR DESCRIPTION
Resolves #1532

Quick fix to remove `<p>` wrapper around `h4` tags defining START DATE, DUE DATE pairs and actual date pairs.