### PR TITLE
[1544] Request text is now shown after invalid cart edit

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,6 @@
 # rubocop:disable ClassLength
 class CatalogController < ApplicationController
+  helper ReservationsHelper # for request_text
   layout 'application_with_sidebar'
 
   before_action :set_equipment_model, only:

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -101,8 +101,7 @@ class ReservationsController < ApplicationController
   def show
   end
 
-  # rubocop:disable BlockNesting
-  def new # rubocop:disable MethodLength, PerceivedComplexity
+  def new # rubocop:disable MethodLength
     if cart.items.empty?
       flash[:error] = 'You need to add items to your cart before making a '\
         'reservation.'
@@ -119,12 +118,6 @@ class ReservationsController < ApplicationController
           flash[:error] = 'Please review the errors below. If uncorrected, '\
             'any reservations with errors will be filed as a request, and '\
             'subject to administrator approval.'
-          if AppConfig.get(:request_text).empty?
-            @request_text = 'Please give a short justification for this '\
-              'equipment request.'
-          else
-            @request_text = AppConfig.get(:request_text)
-          end
         end
       end
 
@@ -134,7 +127,6 @@ class ReservationsController < ApplicationController
                                      reserver_id: cart.reserver_id)
     end
   end
-  # rubocop:enable BlockNesting
 
   def create # rubocop:disable all
     @errors = cart.validate_all

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -57,6 +57,14 @@ module ReservationsHelper
     end
   end
 
+  def request_text
+    if AppConfig.get(:request_text).empty?
+      'Please give a short justification for this equipment request.'
+    else
+      AppConfig.get(:request_text)
+    end
+  end
+
   private
 
   # the "+ 1" terms are to account for the fact that the first

--- a/app/views/reservations/_new_request.html.erb
+++ b/app/views/reservations/_new_request.html.erb
@@ -23,7 +23,7 @@
   </p>
   <%= render partial: 'reservations/edit_reservation_form' %>
   <div class="well">
-    <%= markdown(@request_text) %>
+    <%= markdown(request_text) %>
   </div>
   <%= simple_form_for @reservation do |f| %>
     <div class="form-group text <%= 'error' if @notes_required %>">

--- a/spec/factories/app_configs.rb
+++ b/spec/factories/app_configs.rb
@@ -25,6 +25,6 @@ FactoryGirl.define do
     send_notifications_for_deleted_missed_reservations true
     notify_admin_on_create false
     checkout_persons_can_edit false
-    request_text ''
+    request_text 'tell me whyyy?'
   end
 end

--- a/spec/features/reservations_spec.rb
+++ b/spec/features/reservations_spec.rb
@@ -597,6 +597,7 @@ describe 'Reservations', type: :feature do
         quantity_forms[1].submit_form!
         # loading right page
         expect(page).to have_content 'Confirm Reservation Request'
+        expect(page).to have_content AppConfig.get(:request_text)
         # changes applied
         expect(page).to \
           have_selector("input[value='#{@eq_model.max_per_user + 1}']")
@@ -680,6 +681,7 @@ describe 'Reservations', type: :feature do
         find('#dates_form').submit_form!
         # loads right page
         expect(page).to have_content 'Confirm Reservation Request'
+        expect(page).to have_content AppConfig.get(:request_text)
         # has altered date
         expect(page).to have_selector("input[value='#{bad_due_date}']")
       end


### PR DESCRIPTION
Resolves #1544
- moves request text assignment code to `ReservationsHelper`
- manually include `ReservationsHelper` in `CatalogController`

In principle I'd like to move the reservation/cart update methods from `CatalogController` to `ReservationsController` (since they're ultimately being called from the `ReservationsController#new` page), which would preclude the need to manually include `ReservationsHelper` in `CatalogController` - can someone chime in and let me know if they think it's worth doing?