### PR TITLE
[1521] Add global option to include requests in availability calculations 

### DIFF
--- a/app/controllers/app_configs_controller.rb
+++ b/app/controllers/app_configs_controller.rb
@@ -53,6 +53,6 @@ class AppConfigsController < ApplicationController
                   :checkout_persons_can_edit, :enable_renewals,
                   :override_on_create, :override_at_checkout, :require_phone,
                   :notify_admin_on_create, :disable_user_emails,
-                  :autodeactivate_on_archive)
+                  :autodeactivate_on_archive, :requests_affect_availability)
   end
 end

--- a/app/views/app_configs/_form.erb
+++ b/app/views/app_configs/_form.erb
@@ -48,6 +48,7 @@
 
   <fieldset>
     <legend>Reservation Settings</legend><br />
+    <%= f.input :requests_affect_availability, label: 'Allow requests to affect equipment availability?', hint: 'When enabled, reservation requests will affect equipment item availability before the request is approved.' %>
     <%= f.input :notify_admin_on_create, label: 'Notify admin on creation?',hint: 'When enabled, admins will get an e-mail whenever a reservation is created.' %>
     <%= f.input :request_text, label: 'Reservation request text', input_html: {rows: 10},
       hint: 'This message will be displayed to users who are about to file a reservation request for invalid reservations. You can use markdown in this field' %>

--- a/db/migrate/20160610135455_add_requests_affect_availability_to_app_config.rb
+++ b/db/migrate/20160610135455_add_requests_affect_availability_to_app_config.rb
@@ -1,0 +1,5 @@
+class AddRequestsAffectAvailabilityToAppConfig < ActiveRecord::Migration
+  def change
+    add_column :app_configs, :requests_affect_availability, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160311070200) do
+ActiveRecord::Schema.define(version: 20160610135455) do
 
   create_table "announcements", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20160311070200) do
     t.boolean  "notify_admin_on_create",                                           default: false
     t.boolean  "disable_user_emails",                                              default: false
     t.boolean  "autodeactivate_on_archive",                                        default: false
+    t.boolean  "requests_affect_availability",                                     default: false
   end
 
   create_table "blackouts", force: :cascade do |t|

--- a/spec/controllers/equipment_models_controller_spec.rb
+++ b/spec/controllers/equipment_models_controller_spec.rb
@@ -105,7 +105,7 @@ shared_examples_for 'GET index success' do
 end
 
 describe EquipmentModelsController, type: :controller do
-  before(:each) { mock_app_config }
+  before(:each) { mock_app_config(requests_affect_availability: false) }
   let!(:model) { FactoryGirl.create(:equipment_model) }
 
   it_behaves_like 'calendarable', EquipmentModel

--- a/spec/models/equipment_model_spec.rb
+++ b/spec/models/equipment_model_spec.rb
@@ -370,6 +370,11 @@ describe EquipmentModel, type: :model do
 
         ACTIVE.each { |s| it_behaves_like 'with an active reservation', s }
 
+        context 'when requests_affect_availability is set' do
+          before { mock_app_config(requests_affect_availability: true) }
+          it_behaves_like 'with an active reservation', :request
+        end
+
         context 'with a checked-out, overdue reservation' do
           before do
             @res = FactoryGirl.create(:overdue_reservation,


### PR DESCRIPTION
Resolves #1521 

The `.gitignore` and `.rubocop.yml` updates are there because I have react-related files in my working directory and they aren't ignored on master yet.