### PR TITLE
[1411] Running tests with USE_LDAP enabled outside of Yale breaks things

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,7 @@ RSpec.configure do |config|
   # DatabaseCleaner setup (2016-01-04 based on Rails Testing book)
   config.before(:suite) do
     DatabaseCleaner.clean_with(:deletion)
+    ENV.delete('USE_LDAP')
   end
 
   config.before(:each) do


### PR DESCRIPTION
Resolves #1411

The `UsersController` test failure is fixed in #1595 by stubbing `User.search_ldap`. 

Importing users with LDAP is currently untested, so defaulting `USE_LDAP` to `nil` allows those tests to run even if the variable is set in `.env`. Setting this default would be a lot nicer if #1422 was merged, because we could have a `.env.test` file with `USE_LDAP=0` rather than deleting `USE_LDAP` from the `ENV` hash before running the test suite (my current solution). 

I don't think there are any other tests that hit LDAP; the model method isn't tested. 