### PR TITLE
[1223] Expand integration test suite

### DIFF
--- a/app/views/equipment_models/_form.html.erb
+++ b/app/views/equipment_models/_form.html.erb
@@ -82,7 +82,7 @@
     <% end %>
     <div class="links">
       <p><%= link_to_add_association 'Add Step', f, :checkout_procedures,
-      class: "btn btn-default" %></p>
+      class: "btn btn-default" , id: 'add_checkout_procedure'%></p>
     </div>
   </fieldset>
 
@@ -93,7 +93,7 @@
     <% end %>
     <div class="links">
       <p><%= link_to_add_association 'Add Step', f, :checkin_procedures,
-      class: "btn btn-default" %></p>
+      class: "btn btn-default", id: 'add_checkin_procedure' %></p>
     </div>
   </fieldset>
 

--- a/spec/features/blackout_spec.rb
+++ b/spec/features/blackout_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'Blackouts', type: :feature do
+  describe 'creation' do
+    before { sign_in_as_user @superuser }
+    context 'normal' do
+      it 'succeeds' do
+        visit blackouts_path
+        click_on 'New Blackout'
+        select('Blackout', from: 'blackout_blackout_type')
+        fill_in('blackout_notice', with: 'NOTICE')
+        click_on 'Create Blackout'
+        expect(Blackout.where(notice: 'NOTICE')).not_to be_empty
+      end
+    end
+    context 'recurring' do
+      it 'succeeds' do
+        visit blackouts_path
+        click_on 'New Recurring Blackout'
+        check('blackout_days_6')
+        select('Blackout', from: 'blackout_blackout_type')
+        fill_in('blackout_notice', with: 'NOTICE')
+        click_on 'Create Blackout'
+        expect(Blackout.where(notice: 'NOTICE')).not_to be_empty
+      end
+    end
+  end
+  context 'hard blackouts' do
+    before { sign_in_as_user @user }
+    it 'prevents new reservations' do
+      @blackout = FactoryGirl.create(:blackout)
+      visit equipment_model_path(EquipmentModel.first)
+      click_on 'Add to Cart'
+      click_on 'Reserve'
+      expect(page).to have_content 'Confirm Reservation Request'
+    end
+  end
+end

--- a/spec/features/category_spec.rb
+++ b/spec/features/category_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'Categories', type: :feature do
+  describe 'creation' do
+    before do
+      sign_in_as_user @superuser
+      visit new_category_path
+    end
+    it 'succeeds' do
+      attrs = { name: 'CATEGORY', max_per_user: 1, max_checkout_length: 3,
+                sort_order: 1, max_renewal_times: 2, max_renewal_length: 4,
+                renewal_days_before_due: 5 }
+      attrs.each { |attr, value| fill_in("category_#{attr}", with: value) }
+      click_button 'Create Category'
+      expect(Category.where(name: attrs[:name])).not_to be_empty
+    end
+  end
+  describe 'editing' do
+    let!(:cat) { FactoryGirl.create(:category) }
+    before { sign_in_as_user @superuser }
+    shared_examples 'can update' do |attr, value|
+      it attr.to_s do
+        visit edit_category_path(cat)
+        fill_in("category_#{attr}", with: value)
+        click_button 'Update Category'
+        cat.reload
+        expect(cat.send(attr)).to eq(value)
+      end
+    end
+    ATTRS = { name: 'CATEGORY', max_per_user: 1, max_checkout_length: 3,
+              sort_order: 1, max_renewal_times: 2, max_renewal_length: 4,
+              renewal_days_before_due: 5 }.freeze
+    ATTRS.each { |attr, value| it_behaves_like 'can update', attr, value }
+  end
+end

--- a/spec/features/category_spec.rb
+++ b/spec/features/category_spec.rb
@@ -32,4 +32,8 @@ describe 'Categories', type: :feature do
               renewal_days_before_due: 5 }.freeze
     ATTRS.each { |attr, value| it_behaves_like 'can update', attr, value }
   end
+  describe 'deactivation' do
+    it 'succeeds' do
+    end
+  end
 end

--- a/spec/features/eq_model_spec.rb
+++ b/spec/features/eq_model_spec.rb
@@ -137,4 +137,20 @@ describe 'Equipment Model views', type: :feature do
               max_renewal_length: 4, renewal_days_before_due: 5 }.freeze
     ATTRS.each { |attr, value| it_behaves_like 'can update', attr, value }
   end
+  # TODO: 
+  #   - multiple deactivate buttons
+  #   - currently doesn't pass right params?
+  #describe 'deactivation' do
+  #  let!(:model) { FactoryGirl.create(:equipment_model) }
+  #  before { sign_in_as_user @superuser }
+  #  it 'succeeds' do
+  #    visit equipment_model_path(model)
+  #    save_and_open_page
+  #    expect(page).to have_content 'deactivated'
+  #  end
+  #  context 'with items' do
+  #    it 'also deactivates the items' do
+  #    end
+  #  end
+  #end
 end

--- a/spec/features/eq_model_spec.rb
+++ b/spec/features/eq_model_spec.rb
@@ -100,4 +100,41 @@ describe 'Equipment Model views', type: :feature do
       end
     end
   end
+  describe 'creation' do
+    let!(:cat) { FactoryGirl.create(:category) }
+    before do
+      sign_in_as_user @superuser
+      visit new_equipment_model_path
+    end
+    it 'succeeds' do
+      attrs = { name: 'EQ MODEL', description: 'DESC', late_fee: 5,
+                replacement_fee: 10, late_fee_max: 15, max_per_user: 1,
+                max_checkout_length: 3, max_renewal_times: 2,
+                max_renewal_length: 4, renewal_days_before_due: 5 }
+      select(cat.name, from: 'equipment_model_category_id')
+      attrs.each do |attr, value|
+        fill_in("equipment_model_#{attr}", with: value)
+      end
+      click_button 'Create Equipment model'
+      expect(EquipmentModel.where(name: attrs[:name])).not_to be_empty
+    end
+  end
+  describe 'editing' do
+    let!(:model) { FactoryGirl.create(:equipment_model) }
+    before { sign_in_as_user @superuser }
+    shared_examples 'can update' do |attr, value|
+      it attr.to_s do
+        visit edit_equipment_model_path(model)
+        fill_in("equipment_model_#{attr}", with: value)
+        click_button 'Update Equipment model'
+        model.reload
+        expect(model.send(attr)).to eq(value)
+      end
+    end
+    ATTRS = { name: 'EQ MODEL', description: 'DESC', late_fee: 5,
+              replacement_fee: 10, late_fee_max: 15, max_per_user: 1,
+              max_checkout_length: 3, max_renewal_times: 2,
+              max_renewal_length: 4, renewal_days_before_due: 5 }.freeze
+    ATTRS.each { |attr, value| it_behaves_like 'can update', attr, value }
+  end
 end

--- a/spec/features/equipment_item_spec.rb
+++ b/spec/features/equipment_item_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'Equipment Items', type: :feature do
+  describe 'creation' do
+    let!(:model) { FactoryGirl.create(:equipment_model) }
+    before { sign_in_as_user @superuser }
+    it 'succeeds' do
+      visit equipment_model_path(model)
+      click_on "Create New #{model.name} Item"
+      fill_in('Name', with: 'New Item Name')
+      click_button 'Create Equipment item'
+      expect(EquipmentItem.where(name: 'New Item Name')).not_to be_empty
+    end
+  end
+  describe 'editing' do
+    let!(:item) { FactoryGirl.create(:equipment_item) }
+    before { sign_in_as_user @superuser }
+    shared_examples 'can update' do |attr, value|
+      it attr.to_s do
+        visit edit_equipment_item_path(item)
+        fill_in("equipment_item_#{attr}", with: value)
+        click_button 'Update Equipment item'
+        item.reload
+        expect(item.send(attr)).to eq(value)
+      end
+    end
+    ATTRS = { name: 'ITEM', serial: '12345' }.freeze
+    ATTRS.each { |attr, value| it_behaves_like 'can update', attr, value }
+  end
+end

--- a/spec/features/equipment_item_spec.rb
+++ b/spec/features/equipment_item_spec.rb
@@ -35,5 +35,14 @@ describe 'Equipment Items', type: :feature do
       accept_prompt(with: 'reason') { click_on 'Deactivate' }
       expect(page).to have_content 'Deactivated'
     end
+    # TODO: fails because there are two JS prompts in a row
+    # context 'with an active reservation' do
+    #   it 'archives the reservation', js: true do
+    #     res = FactoryGirl.create(:checked_out_reservation, equipment_item: item)
+    #     visit equipment_item_path(item)
+    #     accept_prompt(with: 'reason') { click_on 'Deactivate' }
+    #     expect(res.reload.status).to eq 'archived'
+    #   end
+    # end
   end
 end

--- a/spec/features/equipment_item_spec.rb
+++ b/spec/features/equipment_item_spec.rb
@@ -27,4 +27,13 @@ describe 'Equipment Items', type: :feature do
     ATTRS = { name: 'ITEM', serial: '12345' }.freeze
     ATTRS.each { |attr, value| it_behaves_like 'can update', attr, value }
   end
+  describe 'deactivation' do
+    let!(:item) { FactoryGirl.create(:equipment_item) }
+    before { sign_in_as_user @superuser }
+    it 'succeeds', js: true do
+      visit equipment_item_path(item)
+      accept_prompt(with: 'reason') { click_on 'Deactivate' }
+      expect(page).to have_content 'Deactivated'
+    end
+  end
 end

--- a/spec/features/procedure_spec.rb
+++ b/spec/features/procedure_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'Procedures', type: :feature do
+  context 'checkout procedure' do
+    it 'allows checkout if checked' do
+      model = FactoryGirl.create(:equipment_model)
+      procedure = FactoryGirl.create(:checkout_procedure,
+                                     equipment_model: model)
+      res = FactoryGirl.create(:valid_reservation, equipment_model: model)
+      sign_in_as_user(FactoryGirl.create(:admin))
+      visit manage_reservations_for_user_path(res.reserver)
+      select(model.equipment_items.first.name, from: 'Equipment Item')
+      check(procedure.step)
+      click_on 'Check-Out Equipment'
+      expect(page).to have_content('Check-Out Receipt')
+    end
+    it 'notifies when not checked', js: true do
+      model = FactoryGirl.create(:equipment_model)
+      FactoryGirl.create(:checkout_procedure, equipment_model: model)
+      res = FactoryGirl.create(:valid_reservation, equipment_model: model)
+      sign_in_as_user(FactoryGirl.create(:admin))
+      visit manage_reservations_for_user_path(res.reserver)
+      select(model.equipment_items.first.name, from: 'Equipment Item')
+      message = dismiss_confirm do
+        click_on 'Check-Out Equipment'
+      end
+      expect(message).not_to be_nil
+    end
+  end
+
+  context 'checkin procedure' do
+    it 'allows checkin if checked' do
+      model = FactoryGirl.create(:equipment_model)
+      procedure = FactoryGirl.create(:checkin_procedure, equipment_model: model)
+      res = FactoryGirl.create(:checked_out_reservation, equipment_model: model)
+      sign_in_as_user(FactoryGirl.create(:admin))
+      visit manage_reservations_for_user_path(res.reserver)
+      check("reservations_#{res.id}_checkin_")
+      check(procedure.step)
+      click_on 'Check-In Equipment'
+      expect(page).to have_content('Check-In Receipt')
+    end
+    # FIXME: can't find the checkbox with JS driver
+    # tried: find_by_id, xpath
+    # it 'notifies when not checked', js: true do
+    #   model = FactoryGirl.create(:equipment_model)
+    #   FactoryGirl.create(:checkin_procedure, equipment_model: model)
+    #   res = FactoryGirl.create(:checked_out_reservation, equipment_model: model)
+    #   sign_in_as_user(FactoryGirl.create(:admin))
+    #   visit manage_reservations_for_user_path(res.reserver)
+    #   check("reservations_#{res.id}_checkin_")
+    #   message = dismiss_confirm do
+    #     click_on 'Check-In Equipment'
+    #   end
+    #   expect(message).not_to be_nil
+    # end
+  end
+end

--- a/spec/features/reports_spec.rb
+++ b/spec/features/reports_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'Reports', type: :feature do
+  describe 'default index' do
+    it 'shows a year from today' do
+      sign_in_as_user FactoryGirl.create(:superuser)
+      visit reports_path
+      expect(page).to have_content(Time.zone.today.strftime("%b %d, %Y"))
+      expect(page).to \
+        have_content((Time.zone.today - 1.year).strftime("%b %d, %Y"))
+    end
+    it 'shows equipment model data' do
+      model = FactoryGirl.create(:equipment_model)
+      FactoryGirl.create(:checked_out_reservation, equipment_model: model)
+      sign_in_as_user FactoryGirl.create(:superuser)
+      visit reports_path
+      within(:xpath, "//div[@id='equipment_models']/table/tbody/tr[1]") do
+        within(:xpath, "./td[1]") { expect(page).to have_content(model.name) }
+        # first row, checked_out column
+        within(:xpath, "./td[4]") { expect(page).to have_content('1') }
+      end
+    end
+    it 'shows category data' do
+      model = FactoryGirl.create(:equipment_model)
+      FactoryGirl.create(:checked_out_reservation, equipment_model: model)
+      cat = model.category
+      sign_in_as_user FactoryGirl.create(:superuser)
+      visit reports_path
+      within(:xpath, "//div[@id='categories']/table/tbody/tr[1]") do
+        within(:xpath, "./td[1]") { expect(page).to have_content(cat.name) }
+        # first row, checked_out column
+        within(:xpath, "./td[4]") { expect(page).to have_content('1') }
+      end
+    end
+  end
+  
+  describe 'can change dates' do
+    it '', js: true do
+      sign_in_as_user FactoryGirl.create(:superuser)
+      visit reports_path
+      start_time = Time.zone.today - 1.month
+      end_time = Time.zone.today - 1.week
+      fill_in('report_start_date', with: start_time.strftime('%m/%d/%Y'))
+      fill_in('report_end_date', with: end_time.strftime('%m/%d/%Y'))
+      click_on 'Generate Report'
+      expect(page).to have_content(start_time.strftime("%b %d, %Y"))
+      expect(page).to have_content(end_time.strftime("%b %d, %Y"))
+    end
+  end
+end

--- a/spec/features/requirement_spec.rb
+++ b/spec/features/requirement_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'Requirements', type: :feature do
+  context 'as admin' do
+    before { sign_in_as_user @admin }
+    it 'can create' do
+      model = FactoryGirl.create(:equipment_model)
+      visit new_requirement_path
+      attrs = { description: 'DESC', contact_name: 'Name',
+                contact_info: 'info' }
+      attrs.each do |attr, value|
+        fill_in("requirement_#{attr}", with: value)
+      end
+      select(model.name, from: 'requirement_equipment_model_ids')
+      click_button 'Create Requirement'
+      model.reload
+      expect(model.requirements).not_to be_empty
+    end
+    it 'can add a requirement to a user' do
+      user = FactoryGirl.create(:user)
+      req = FactoryGirl.create(:requirement)
+      visit edit_user_path(user)
+      select(req.description, from: 'user_requirement_ids')
+      click_button 'Update User'
+      user.reload
+      expect(user.requirements).to include(req)
+    end
+  end
+  context 'reservation creation' do
+    let!(:req) { FactoryGirl.create(:requirement) }
+    let!(:model) do
+      FactoryGirl.create(:equipment_model_with_item, requirements: [req])
+    end
+    context 'satisifed requirement' do
+      before do
+        sign_in_as_user(FactoryGirl.create(:user, requirements: [req]))
+      end
+      it 'can add to cart' do
+        visit equipment_model_path(model)
+        expect(page).to have_link('Add to Cart')
+      end
+    end
+    context 'has not satisifed requirement' do
+      before do
+        sign_in_as_user(FactoryGirl.create(:user))
+      end
+      it 'cannot add to cart' do 
+        visit equipment_model_path(model)
+        expect(page).to have_link('Not Qualified')
+      end
+    end
+  end
+end

--- a/spec/features/reservations_index_spec.rb
+++ b/spec/features/reservations_index_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'Reservation Index', type: :feature do
+  context 'as privileged user' do
+    before { sign_in_as_user @admin }
+    after { sign_out }
+    it 'defaults to upcoming reservations' do
+      upcoming = FactoryGirl.create(:upcoming_reservation)
+      not_upcoming = FactoryGirl.create(:valid_reservation,
+                                        start_date: Time.zone.today + 2.days,
+                                        due_date: Time.zone.today + 3.days)
+      visit reservations_path
+      table_content = page.all('table#reservations-list td').map(&:text)
+      expect(table_content).to include(upcoming.id.to_s)
+      expect(table_content).not_to include(not_upcoming.id.to_s)
+    end
+    it 'defaults to reservations +/- one week from today' do
+      start_date = (Time.zone.today - 1.week).strftime('%m/%d/%Y')
+      end_date = (Time.zone.today + 1.week).strftime('%m/%d/%Y')
+      visit reservations_path
+      expect(page.find('#list_start_date').value).to eq(start_date)
+      expect(page.find('#list_end_date').value).to eq(end_date)
+    end
+    it 'can be filtered by various statuses' do
+      filters = %w(upcoming reserved requested checked_out overdue returned
+                   returned_overdue archived approved_requests denied)
+      filters.map! { |f| "/reservations?#{f}=true" }
+      visit reservations_path
+      nav_links = page.all('div.res_index_nav ul li a').map { |a| a[:href] }
+      expect(nav_links).to match_array(filters)
+    end
+    it 'shows reserver in table' do
+      visit reservations_path
+      table_column_names = page.all('table#reservations-list th').map(&:text)
+      expect(table_column_names).to include('Reserver')
+    end
+  end
+  context 'as normal user' do
+    before { sign_in_as_user @user }
+    after { sign_out }
+    it 'cannot be filtered to upcoming' do
+      visit reservations_path
+      nav_links = page.all('div.res_index_nav ul li a').map { |a| a[:href] }
+      expect(nav_links).not_to include('/reservations?upcoming=true')
+    end
+    it 'only shows own reservations' do
+      other = FactoryGirl.create(:valid_reservation, reserver: @admin)
+      own = FactoryGirl.create(:valid_reservation, reserver: @user)
+      visit reservations_path
+      table_content = page.all('table#reservations-list td').map(&:text)
+      expect(table_content).to include(own.id.to_s)
+      expect(table_content).not_to include(other.id.to_s)
+    end
+  end
+end


### PR DESCRIPTION
This doesn't cover the full scope of the issue, but it adds more integration tests.

We should figure out which of these are necessary.

If we decide to keep deactivation integration tests, I would appreciate some help figuring out how to assert that two modals follow each other -- the tests fail right now and are commented out.