### PR TITLE
Fix phone regex parsing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ActiveRecord::Base
             :last_name,
             :affiliation, presence: true
   validates :phone, presence: true,
-                    format: { with: %r{/\A\S[0-9\+\/\(\)\s\-]*\z/i} },
+                    format: { with: %r{\A[0-9\+\/\(\)\s\-]*\z} },
                     length: { minimum: 10 },
                     unless: ->(u) { u.skip_phone_validation? }
 


### PR DESCRIPTION
    Resolves #1633
    - fixed the regex string to look for only numbers and ()