### PR TITLE
Repair equipment_model generator to handle ordering

### DIFF
--- a/db/migrate/20160329015527_add_ordering.rb
+++ b/db/migrate/20160329015527_add_ordering.rb
@@ -1,8 +1,9 @@
 class AddOrdering < ActiveRecord::Migration
   def up
-    unless column_exists?(:equipment_models, :ordering)
-  	 add_column :equipment_models, :ordering, :integer, :null => false
-    end
+    return if column_exists?(:equipment_models, :ordering) 
+  	
+    add_column :equipment_models, :ordering, :integer, :null => false
+    
   	# store ActiveRecord connection to run queries
     conn = ActiveRecord::Base.connection
 

--- a/lib/seed/equipment_model_generator.rb
+++ b/lib/seed/equipment_model_generator.rb
@@ -17,7 +17,7 @@ module EquipmentModelGenerator
       em.renewal_days_before_due = rand(0..9001)
       em.photo = File.open(IMAGES.sample) unless NO_PICS
       em.associated_equipment_models = EquipmentModel.all.sample(6)
-      em.ordering = 1
+      em.ordering = EquipmentModel.count
     end
   end
 end

--- a/lib/seed/reservation_generator_helper.rb
+++ b/lib/seed/reservation_generator_helper.rb
@@ -8,8 +8,9 @@ module ReservationGeneratorHelper
                         notes: FFaker::HipsterIpsum.paragraph(2),
                         start_date: Time.zone.today)
     max_checkout_len = r.equipment_model.maximum_checkout_length
+    last = [max_checkout_len - 1, 1].max
     duration = max_checkout_len -
-               rand_val(first: 1, last: max_checkout_len - 1,
+               rand_val(first: 1, last: last,
                         default: 1, random: random)
     r.due_date = r.start_date + duration.days
     r

--- a/spec/factories/equipment_models.rb
+++ b/spec/factories/equipment_models.rb
@@ -2,7 +2,7 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 FactoryGirl.define do
   sequence(:unique_id) { |n| n }
-  sequence(:ordering) { |n| n }
+  sequence(:ordering) { |n| n + 1 }
   factory :equipment_model do
     name
     description 'This is a model'

--- a/spec/lib/generator_spec.rb
+++ b/spec/lib/generator_spec.rb
@@ -8,15 +8,22 @@ describe Generator do
       expect(Generator.send(method)).to be_truthy
     end
   end
+  shared_examples 'generates multiple valid' do |method, klass|
+    it method.to_s do
+      expect(5.times { Generator.send(method) }).to be_truthy
+      expect(klass.count).to eq(5)
+    end
+  end
   OBJECTS.each { |o| it_behaves_like 'generates a valid', o }
 
   context 'blackout generation' do
     before { Generator.user }
-    it_behaves_like 'generates a valid', :blackout
+    it_behaves_like 'generates multiple valid', :blackout, Blackout
   end
   context 'equipment_model generation' do
     before { Generator.category }
-    it_behaves_like 'generates a valid', :equipment_model
+    it_behaves_like 'generates multiple valid', :equipment_model,
+                    EquipmentModel
   end
 
   context 'requiring a category and equipment model' do
@@ -24,9 +31,12 @@ describe Generator do
       Generator.category
       Generator.equipment_model
     end
-    it_behaves_like 'generates a valid', :equipment_item
-    it_behaves_like 'generates a valid', :checkout_procedure
-    it_behaves_like 'generates a valid', :checkin_procedure
+    it_behaves_like 'generates multiple valid', :equipment_item,
+                    EquipmentItem
+    it_behaves_like 'generates multiple valid', :checkout_procedure,
+                    CheckoutProcedure
+    it_behaves_like 'generates multiple valid', :checkin_procedure,
+                    CheckinProcedure
   end
 
   context 'reservation generation' do


### PR DESCRIPTION
Resolves #1662
- set ordering to number of existing models in equipment_model generation
- add validations for generating multiple objects
- resolves error that can occur when randomly generating reservations for
  equipment_model with max_checkout_length = 1