### PR TITLE
[1690] Fix Heroku deployment again (switch to MySQL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Put headers in order corresponding to their order on reservation page ([#1661](https://github.com/YaleSTC/reservations/issues/1661)).
 * Fixed the equipment model seed script generator ([#1662](https://github.com/YaleSTC/reservations/issues/1662)).
 * Fixed broken database migrations ([#1676](https://github.com/YaleSTC/reservations/issues/1676), [#1684](https://github.com/YaleSTC/reservations/issues/1684)).
-* Fixed Heroku deployments by updating post-deploy script ([#1680](https://github.com/YaleSTC/reservations/issues/1680)).
+* Fixed Heroku deployments by updating post-deploy script and switching to MySQL ([#1680](https://github.com/YaleSTC/reservations/issues/1680), [#1690](https://github.com/YaleSTC/reservations/issues/1690)).
 
 ### Added
 * Added ordering of equipment models within the catalog ([#1418](https://github.com/YaleSTC/reservations/issues/1418)).

--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,6 @@ group :production do
 end
 
 group :heroku do
-  gem 'pg', '~> 0.18.4'
   gem 'unicorn', '~> 5.1.0'
   gem 'rack-timeout', '~> 0.4.2'
   gem 'aws-sdk', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,6 @@ GEM
     permanent_records (4.1.5)
       activerecord (>= 4.2.0)
       activesupport (>= 4.2.0)
-    pg (0.18.4)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -511,7 +510,6 @@ DEPENDENCIES
   paperclip (~> 5.1.0)
   party_foul (~> 1.5.5)
   permanent_records (= 4.1.5)
-  pg (~> 0.18.4)
   pry (~> 0.10.4)
   pry-byebug (~> 3.4.2)
   pry-rails (~> 0.3.6)
@@ -548,4 +546,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Dependency Status](https://gemnasium.com/YaleSTC/reservations.svg)](https://gemnasium.com/YaleSTC/reservations)
 [![Inline docs](http://inch-ci.org/github/yalestc/reservations.svg?branch=master&style=flat)](http://inch-ci.org/github/yalestc/reservations)
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://github.com/YaleSTC/reservations/wiki/Heroku-Deployment-Guide)
 
 ![](http://yalestc.github.io/reservations/images/screenshot.png)
 

--- a/app.json
+++ b/app.json
@@ -69,10 +69,13 @@
     },
     "AWS_SECRET_ACCESS_KEY": {
       "description": "AWS secret access key"
+    },
+    "DATABASE_URL": {
+      "description": "Copy in CLEARDB_DATABASE_URL and change mysql to mysql2"
     }
   },
   "addons": [
-    "heroku-postgresql",
+    "cleardb:ignite",
     "sendgrid:starter",
     "scheduler:standard"
   ]


### PR DESCRIPTION
Resolves #1690
- Remove pg gem from Gemfile
- Add cleardb:ignite add-on
- Add DATABASE_URL ENV variable
- Update Travis script to install Ghostscript (due to update in Ubuntu
distro being used)