### PR TITLE
[1708] Permit the use of AWS regions other than us-east-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 ### Fixed
 * Fixed new user signup when guest access is disabled ([#1706](https://github.com/YaleSTC/reservations/issues/1706)).
+* Permit the use of S3 buckets in regions other than US-East-1 ([#1708](https://github.com/YaleSTC/reservations/issues/1708)).
 * Fixed issue with displaying future reservations ([#1711](https://github.com/YaleSTC/reservations/issues/1711)).
 * Fix issue with checkout form populating the same equipment items for all models ([#1713](https://github.com/YaleSTC/reservations/issues/1713)).
 

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
-class AppConfig < ActiveRecord::Base
+
+class AppConfig < ApplicationRecord
   has_attached_file :favicon,
-                    url: '/system/:attachment/:id/:style/favicon.:extension'
+                    url: paperclip_url(filename: 'favicon'),
+                    path: ':rails_root/public/attachments/app_configs/'\
+                      ':attachment/:id/:style/favicon.:extension'
 
   validates_with AttachmentContentTypeValidator,
                  attributes: :favicon,
@@ -35,7 +38,7 @@ class AppConfig < ActiveRecord::Base
   # e-mail address if no separate address is specified
   def self.contact_email
     contact_email = get(:contact_link_location, nil)
-    if contact_email.nil? || contact_email.empty?
+    if contact_email.blank?
       get(:admin_email, nil)
     else
       contact_email

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,12 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.paperclip_url(filename: ':basename')
+    if ENV['ENABLE_PAPERCLIP_S3'].present?
+      return Paperclip::Attachment.default_options[:url]
+    end
+    class_plural = to_s.underscore.pluralize
+    "/attachments/#{class_plural}/:attachment/:id/:style/#{filename}.:extension"
+  end
 end

--- a/app/models/equipment_model.rb
+++ b/app/models/equipment_model.rb
@@ -88,8 +88,7 @@ class EquipmentModel < ApplicationRecord
                       thumbnail:
                         '-background none -gravity center -extent 260x180'
                     },
-                    url: '/attachments/equipment_models/:attachment/:id/'\
-                      ':style/:basename.:extension',
+                    url: paperclip_url,
                     path: ':rails_root/public/attachments/equipment_models/'\
                       ':attachment/:id/:style/:basename.:extension',
                     default_url: '/fat_cat.jpeg',
@@ -97,8 +96,7 @@ class EquipmentModel < ApplicationRecord
 
   has_attached_file :documentation, # generates document
                     content_type: 'application/pdf',
-                    url: '/attachments/equipment_models/:attachment/:id/'\
-                      ':style/:basename.:extension',
+                    url: paperclip_url,
                     path: ':rails_root/public/attachments/equipment_models/'\
                       ':attachment/:id/:style/:basename.:extension',
                     preserve_files: true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,12 +49,13 @@ Rails.application.configure do
   if ENV['ENABLE_PAPERCLIP_S3']
     config.paperclip_defaults = {
       storage: :s3,
+      bucket: ENV['S3_BUCKET_NAME'],
+      s3_region: ENV['AWS_S3_REGION'],
+      url: ':s3_domain_url',
       s3_credentials: {
-        bucket: ENV['S3_BUCKET_NAME'],
         access_key_id: ENV['AWS_ACCESS_KEY_ID'],
         secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
-      },
-      s3_region: ENV['AWS_S3_REGION']
+      }
     }
   end
 


### PR DESCRIPTION
Resolves #1708
- Add `ApplicationRecord.paperclip_url` to override custom defaults when using S3
- Made `AppConfig` inherit from `ApplicationRecord` instead of `ActiveRecord::Base`