### PR TITLE
[1715] Fix deactivation / activation by implement our own soft deletion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ HasAndBelongsToMany:
   Enabled: false
 Rails:
   Enabled: true
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 * This file will be updated whenever a new release is put into production.
 * Any problems should be reported via the "report an issue" link in the footer of the application.
 
+## Unreleased
+### Fixed
+* Fixed issues with deactivation / activation by removing permanent_records ([#1715](https://github.com/YaleSTC/reservations/issues/1715)).
+
 ## v6.3.1 - 2018-05-31
 ### Fixed
 * Fixed issues with AWS S3 and Paperclip ([#1702](https://github.com/YaleSTC/reservations/issues/1702)).

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'paperclip', '~> 5.1.0'
 gem 'rubyzip', '~> 1.2.1'
 
 # soft deletion
-gem 'permanent_records', '= 4.1.5'
 gem 'nilify_blanks', '~> 1.2.1'
 
 # ui
@@ -89,6 +88,7 @@ group :development, :test do
   gem 'codeclimate-test-reporter', '~> 1.0.8'
   gem 'database_cleaner', '~> 1.6.1'
   gem 'rubocop', '~> 0.49.1', require: false
+  gem 'timecop', '~> 0.9.1'
 end
 
 group :development, :test, :heroku do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,9 +268,6 @@ GEM
       ast (~> 2.2)
     party_foul (1.5.5)
       octokit (~> 3.1)
-    permanent_records (4.1.5)
-      activerecord (>= 4.2.0)
-      activesupport (>= 4.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -445,6 +442,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
+    timecop (0.9.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -511,7 +509,6 @@ DEPENDENCIES
   nilify_blanks (~> 1.2.1)
   paperclip (~> 5.1.0)
   party_foul (~> 1.5.5)
-  permanent_records (= 4.1.5)
   pry (~> 0.10.4)
   pry-byebug (~> 3.4.2)
   pry-rails (~> 0.3.6)
@@ -540,6 +537,7 @@ DEPENDENCIES
   spring-commands-rspec (~> 1.0.4)
   therubyracer (~> 0.12.3)
   thin (~> 1.7.0)
+  timecop (~> 0.9.1)
   uglifier (~> 3.2.0)
   unicorn (~> 5.1.0)
   whenever (~> 0.9.7)
@@ -548,4 +546,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.3
+   1.16.2

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -50,7 +50,7 @@ class AnnouncementsController < ApplicationController
   end
 
   def destroy
-    @announcement.destroy(:force)
+    @announcement.destroy
     redirect_to(announcements_url)
   end
 

--- a/app/controllers/blackouts_controller.rb
+++ b/app/controllers/blackouts_controller.rb
@@ -107,15 +107,13 @@ class BlackoutsController < ApplicationController
   end
 
   def destroy
-    @blackout.destroy(:force)
+    @blackout.destroy
     redirect_to blackouts_url
   end
 
   def destroy_recurring
     blackout_set = Blackout.where('set_id = ?', @blackout.set_id)
-    blackout_set.each do |blackout|
-      blackout.destroy(:force)
-    end
+    blackout_set.each(&:destroy)
     flash[:notice] = 'All blackouts in the set were successfully destroyed.'
     redirect_to(blackouts_path) && return
   end

--- a/app/controllers/requirements_controller.rb
+++ b/app/controllers/requirements_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 class RequirementsController < ApplicationController
   load_and_authorize_resource
   before_action :set_current_requirement,
-                only: [:show, :edit, :update, :destroy]
+                only: %i[show edit update destroy]
 
   # ------------- before filter methods ------------- #
   def set_current_requirement
@@ -14,15 +15,13 @@ class RequirementsController < ApplicationController
     @requirements = Requirement.all
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @requirement = Requirement.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @requirement = Requirement.new(requirement_params)
@@ -42,7 +41,7 @@ class RequirementsController < ApplicationController
   end
 
   def destroy
-    @requirement.destroy(:force)
+    @requirement.destroy
     redirect_to requirements_url
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Category < ApplicationRecord
+  include SoftDeletable
   include Searchable
   searchable_on(:name)
 
@@ -37,5 +38,13 @@ class Category < ApplicationRecord
 
   def maximum_checkout_length
     max_checkout_length || Float::INFINITY
+  end
+
+  private
+
+  # We only need to specify equipment_models here, all other associations will
+  # cascade as those are destroyed.
+  def associated_records
+    equipment_models
   end
 end

--- a/app/models/checkin_procedure.rb
+++ b/app/models/checkin_procedure.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
-class CheckinProcedure < ActiveRecord::Base
+
+class CheckinProcedure < ApplicationRecord
+  include SoftDeletable
+
   belongs_to :equipment_model
+
+  private
+
+  # No associated records for soft deletion
+  def associated_records
+    []
+  end
 end

--- a/app/models/checkout_procedure.rb
+++ b/app/models/checkout_procedure.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
-class CheckoutProcedure < ActiveRecord::Base
+
+class CheckoutProcedure < ApplicationRecord
+  include SoftDeletable
+
   belongs_to :equipment_model
+
+  private
+
+  # No associated records for soft deletion
+  def associated_records
+    []
+  end
 end

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module SoftDeletable
+  extend ActiveSupport::Concern
+
+  included do
+    # "Soft delete" - set deleted_at if it is nil, actually destroy the record
+    # if forced.
+    #
+    # @param force [Boolean]
+    def destroy(force = nil)
+      return force_destroy_record if force == :force
+      return self if deleted?
+      soft_destroy_record
+    end
+
+    # Revive a soft-deleted record and associated records if soft-deleted,
+    # otherwise return self
+    def revive
+      return self unless deleted?
+      ActiveRecord::Base.transaction do
+        update_attributes(deleted_at: nil)
+        revive_associated_records
+      end
+    end
+
+    # Whether or not a record is deleted
+    def deleted?
+      deleted_at.present?
+    end
+
+    private
+
+    def force_destroy_record
+      ActiveRecord::Base.transaction do
+        destroy_associated_records(:force)
+        method(:destroy).super_method.call
+      end
+    end
+
+    def soft_destroy_record
+      ActiveRecord::Base.transaction do
+        destroy_associated_records
+        update_attributes(deleted_at: Time.zone.now)
+      end
+    end
+
+    def destroy_associated_records(force = nil)
+      associated_records.each { |r| r.destroy(force) }
+    end
+
+    def revive_associated_records
+      associated_records.each(&:revive)
+    end
+
+    # This should return an array of all associated records of an object that
+    # should be soft deleted with it (i.e. those that have dependent: :destroy
+    # set). In principle we could figure this out automatically but in the
+    # interest of simplicity we'll just define it manually for each class.
+    def associated_records
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/models/equipment_item.rb
+++ b/app/models/equipment_item.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-class EquipmentItem < ActiveRecord::Base
+
+class EquipmentItem < ApplicationRecord # rubocop:disable Metrics/ClassLength
+  include SoftDeletable
   include Linkable
   include Searchable
 
@@ -98,8 +100,10 @@ class EquipmentItem < ActiveRecord::Base
         old_val = diff[0] ? EquipmentModel.find(diff[0]).name : 'nil'
         new_val = diff[1] ? EquipmentModel.find(diff[1]).name : 'nil'
       end
-      new_notes += "\n#{name} changed from " + old_val + ' to ' + new_val\
-        + '.' if old_val && new_val
+      if old_val && new_val
+        new_notes += "\n#{name} changed from " + old_val + ' to ' + new_val\
+          + '.'
+      end
     end
     new_notes += "\n\n" + notes
     self.notes = new_notes.strip
@@ -127,5 +131,13 @@ class EquipmentItem < ActiveRecord::Base
     save!
     destroy
     self
+  end
+
+  private
+
+  # Equipment items don't have any associated records that are soft-deleted with
+  # them
+  def associated_records
+    []
   end
 end

--- a/app/models/equipment_model.rb
+++ b/app/models/equipment_model.rb
@@ -3,6 +3,7 @@
 # rubocop:disable ClassLength
 class EquipmentModel < ApplicationRecord
   include ApplicationHelper
+  include SoftDeletable
   include Linkable
   include Searchable
 
@@ -201,5 +202,13 @@ class EquipmentModel < ApplicationRecord
     return false if reserver_id.nil?
     reserver = User.find(reserver_id)
     !(requirements - reserver.requirements).empty?
+  end
+
+  private
+
+  # Equipment model deactivation also deactivates all associated checkin and
+  # checkout procedures as well as all equipment items.
+  def associated_records
+    equipment_items + checkin_procedures + checkout_procedures
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,8 +63,6 @@ module Reservations
     # Load all helpers in all views
     config.action_controller.include_all_helpers = true
 
-    PermanentRecords.dependent_record_window = 10.seconds
-
     # set up routing options for Reports (at a minimum)
     config.after_initialize do
       Rails.application.routes.default_url_options =

--- a/spec/concerns/soft_deletable_spec.rb
+++ b/spec/concerns/soft_deletable_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for 'soft deletable' do
+  let(:model) { described_class }
+
+  describe '#deleted?' do
+    it 'returns true if the deleted_at attribute is present' do
+      obj = model.new(deleted_at: Time.zone.now)
+      expect(obj).to be_deleted
+    end
+
+    it 'returns false if the deleted_at attribute is nil' do
+      obj = model.new(deleted_at: nil)
+      expect(obj).not_to be_deleted
+    end
+  end
+
+  describe '#destroy' do
+    let!(:obj) { FactoryGirl.create(model.to_s.underscore.to_sym) }
+
+    it 'sets the deleted_at attribute by default' do
+      allow(obj).to receive(:deleted?).and_return(false)
+      allow(obj).to receive(:associated_records).and_return([])
+      # rounding necessary due to MySQL rounding in the database
+      time = Time.zone.now.round(0)
+      Timecop.freeze(time) do
+        expect { obj.destroy }.to change { obj.reload.deleted_at }
+          .from(nil).to(time)
+      end
+    end
+    it 'actually destroys the object if :force is passed' do
+      expect { obj.destroy(:force) }.to change { model.count }.by(-1)
+    end
+    it 'returns the object if it has already been deleted' do
+      allow(obj).to receive(:deleted?).and_return(true)
+      expect(obj.destroy).to eq(obj)
+    end
+
+    context 'with associations' do
+      let(:associated) { instance_spy(model) }
+
+      before do
+        allow(obj).to receive(:associated_records).and_return([associated])
+      end
+
+      it 'calls destroy on associated records' do
+        obj.destroy
+        expect(associated).to have_received(:destroy)
+      end
+      it 'passes along the force parameter' do
+        obj.destroy(:force)
+        expect(associated).to have_received(:destroy).with(:force)
+      end
+    end
+  end
+
+  describe '#revive' do
+    let!(:obj) { FactoryGirl.create(model.to_s.underscore.to_sym) }
+
+    it 'unsets the deleted_at attribute by default' do
+      obj.update!(deleted_at: Time.zone.now) # necessary so that it changes
+      allow(obj).to receive(:deleted?).and_return(true)
+      allow(obj).to receive(:associated_records).and_return([])
+      expect { obj.revive }.to change { obj.reload.deleted_at }.to(nil)
+    end
+    it 'returns the object if it is not deleted' do
+      allow(obj).to receive(:deleted?).and_return(false)
+      expect(obj.revive).to eq(obj)
+    end
+
+    context 'with associations' do
+      let(:associated) { instance_spy(model) }
+
+      before do
+        allow(obj).to receive(:associated_records).and_return([associated])
+      end
+
+      it 'calls revive on associated records' do
+        allow(obj).to receive(:deleted?).and_return(true)
+        obj.revive
+        expect(associated).to have_received(:revive)
+      end
+    end
+  end
+end

--- a/spec/features/eq_model_deactivation_spec.rb
+++ b/spec/features/eq_model_deactivation_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Equipment Model deactivation', type: :feature do
+  let(:eq_model) { FactoryGirl.create(:equipment_model) }
+
+  before do
+    FactoryGirl.create(:equipment_item, equipment_model: eq_model)
+  end
+
+  after { sign_out }
+
+  shared_examples 'success' do
+    it 'can deactivate and reactivate', js: true do
+      visit equipment_model_path(eq_model)
+      click_link 'Deactivate',
+                 href: "/equipment_models/#{eq_model.id}/deactivate"
+      click_link 'Activate', href: "/equipment_models/#{eq_model.id}/activate"
+      expect(page).to have_css('.alert.alert-success',
+                               text: /Successfully reactivated/)
+    end
+  end
+
+  shared_examples 'unauthorized' do
+    it 'cannot deactivate' do
+      visit equipment_model_path(eq_model)
+      expect(page).not_to have_link 'Deactivate'
+    end
+  end
+
+  context 'as superuser' do
+    before { sign_in_as_user @superuser }
+
+    it_behaves_like 'success'
+  end
+
+  context 'as admin' do
+    before { sign_in_as_user @admin }
+
+    it_behaves_like 'success'
+  end
+
+  context 'as checkout person' do
+    before { sign_in_as_user @checkout_person }
+
+    it_behaves_like 'unauthorized'
+  end
+
+  context 'as patron' do
+    before { sign_in_as_user @user }
+
+    it_behaves_like 'unauthorized'
+  end
+
+  context 'as guest' do
+    it_behaves_like 'unauthorized'
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
+require 'concerns/soft_deletable_spec.rb'
 
 describe Category, type: :model do
+  it_behaves_like 'soft deletable'
+
   before(:each) do
     @category = FactoryGirl.build(:category)
   end

--- a/spec/models/checkin_procedure_spec.rb
+++ b/spec/models/checkin_procedure_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
+require 'concerns/soft_deletable_spec.rb'
 
 describe CheckinProcedure, type: :model do
+  it_behaves_like 'soft deletable'
+
   it { is_expected.to belong_to(:equipment_model) }
 end

--- a/spec/models/checkout_procedure_spec.rb
+++ b/spec/models/checkout_procedure_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
+require 'concerns/soft_deletable_spec.rb'
 
 describe CheckoutProcedure, type: :model do
+  it_behaves_like 'soft deletable'
+
   it { is_expected.to belong_to(:equipment_model) }
 end

--- a/spec/models/equipment_item_spec.rb
+++ b/spec/models/equipment_item_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'concerns/linkable_spec.rb'
+require 'concerns/soft_deletable_spec.rb'
 
 describe EquipmentItem, type: :model do
   include ActiveSupport::Testing::TimeHelpers
 
   it_behaves_like 'linkable'
+  it_behaves_like 'soft deletable'
 
   describe 'basic validations' do
     subject(:item) { FactoryGirl.build(:equipment_item) }

--- a/spec/models/equipment_model_spec.rb
+++ b/spec/models/equipment_model_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-# rubocop:disable Lint/AmbiguousBlockAssociation
-
 require 'spec_helper'
 require 'concerns/linkable_spec.rb'
+require 'concerns/soft_deletable_spec.rb'
 
 describe EquipmentModel, type: :model do
   it_behaves_like 'linkable'
+  it_behaves_like 'soft deletable'
+
   def mock_eq_model(**attrs)
     FactoryGirl.build_stubbed(:equipment_model, **attrs)
   end


### PR DESCRIPTION
Resolves #1715
- Remove gem permanent_records
- Add SoftDeletable concern that allows for any model that has a
  `deleted_at` attribute to implement a form of soft deletion by writing
  to that attribute instead of removing the record by default.
- Add feature spec for deactivation of equipment model