### PR TITLE
Fix flashes escaping html and TOS display bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 ### Fixed
+* Fixed issues with escaped HTML in flashes and elsewhere ([#1705](https://github.com/YaleSTC/reservations/issues/1705)).
 * Fixed issues with deactivation / activation by removing permanent_records ([#1715](https://github.com/YaleSTC/reservations/issues/1715)).
 
 ## v6.3.1 - 2018-05-31

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module UsersHelper
   def active_tab(key)
     return 'active' if key == :current_equipment
@@ -22,5 +23,17 @@ module UsersHelper
       link_to 'Unban', unban_user_path(user), class: 'btn btn-success',
                                               method: :put
     end
+  end
+
+  def tos_attestation(current_user:, user:)
+    if user_viewing_other_user?(current_user: current_user, user: user)
+      return 'User accepts'
+    end
+    'I accept'
+  end
+
+  def user_viewing_other_user?(current_user:, user:)
+    return false if current_user.nil? || current_user == user
+    true
   end
 end

--- a/app/views/layouts/_flash_alerts.html.erb
+++ b/app/views/layouts/_flash_alerts.html.erb
@@ -4,7 +4,7 @@
     <% unless msg.blank? %>
       <%= content_tag :div, id: "flash_#{name}", role: 'alert', class: "alert alert-#{(name == :notice || name == 'notice') ? "success" : "danger"} alert-dismissable" do %>
         <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <%= markdown(msg, false).strip.gsub(/\n/, "<br />") %>
+        <%= sanitize(markdown(msg, true).strip.gsub(/\n/, "<br />")) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/terms_of_service/_user_accepted.html.erb
+++ b/app/views/terms_of_service/_user_accepted.html.erb
@@ -1,9 +1,8 @@
 <% accepted = @user.terms_of_service_accepted == true %>
 
 <%= f.input :terms_of_service_accepted, # users(admins) cannot accept ToS for other users
-          input_html: {value: accepted, disabled: !(current_user == @user || !current_user)},
-          label: ("#{ (current_user == @user || !current_user) ? 'I accept' : 'User accepts'} the #{
-                    link_to('Terms of Service', tos_path, target: '_blank')}")  %>
+            input_html: { value: accepted, disabled: user_viewing_other_user?(current_user: current_user, user: @user) },
+            label: sanitize("#{tos_attestation(current_user: current_user, user: @user)} the #{link_to('Terms of Service', tos_path, target: '_blank')}") %>
 
 <% if can? :manage, Reservation %>
   <%= f.input :created_by_admin, as: :hidden, value: true %>

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe UsersHelper, type: :helper do
+  describe '.tos_attestation' do
+    let(:user1) { FactoryGirl.build_stubbed :user }
+    let(:user2) { FactoryGirl.build_stubbed :user }
+
+    it 'returns "I accept" when the user is acting on their own behalf' do
+      result = helper.tos_attestation(current_user: user1, user: user1)
+      expect(result).to eq('I accept')
+    end
+
+    it "returns 'User accepts' when the user is acting on another's behalf" do
+      result = helper.tos_attestation(current_user: user1, user: user2)
+      expect(result).to eq('User accepts')
+    end
+
+    it 'returns "I accept" when the current user is not present' do
+      result = helper.tos_attestation(current_user: nil, user: user1)
+      expect(result).to eq('I accept')
+    end
+  end
+
+  describe '.user_viewing_other_user?' do
+    let(:user1) { FactoryGirl.build_stubbed :user }
+    let(:user2) { FactoryGirl.build_stubbed :user }
+
+    it 'returns true when a user is signed in and viewing another user' do
+      result =
+        helper.user_viewing_other_user?(current_user: user1, user: user2)
+      expect(result).to be_truthy
+    end
+
+    it 'returns false when a user is signed in and viewing themselves' do
+      result =
+        helper.user_viewing_other_user?(current_user: user1, user: user1)
+      expect(result).to be_falsey
+    end
+
+    it 'returns false when a user is not signed in' do
+      result =
+        helper.user_viewing_other_user?(current_user: nil, user: user1)
+      expect(result).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
I think this got left off when doing the security scrub of `html_safe`. Changed the `filter_html` to `true`by default to scrub any weird tags users may have put in the DB.

We may want to think about scrubbing user inputs before persisting data in the future.