### PR TITLE
[1748] Allow for bulk user role updates with only usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 * This file will be updated whenever a new release is put into production.
 * Any problems should be reported via the "report an issue" link in the footer of the application.
 
-## Unreleased - 2018-08-03
+## v6.3.4 - 2018-08-03
+### Changed
+* Allowed for bulk-updating of user roles with a csv import with just usernames ([#1748](https://github.com/YaleSTC/reservations/issues/1748)).
+
 ### Fixed
 * Fixed broken renewals when reservations were the maximum checkout length ([#1734](https://github.com/YaleSTC/reservations/issues/1734)).
-* Fix issue with the manage reservation button for approved requests ([1747](https://github.com/YaleSTC/reservations/issues/1747))
-* Fix unauthorized display of procedures and equipment items ([1749](https://github.com/YaleSTC/reservations/issues/1749))
+* Fixed issue with the manage reservation button for approved requests ([1747](https://github.com/YaleSTC/reservations/issues/1747))
+* Fixed unauthorized display of procedures and equipment items ([1749](https://github.com/YaleSTC/reservations/issues/1749))
 
 ## v6.3.3 - 2018-07-20
 ### Fixed

--- a/lib/csv_import.rb
+++ b/lib/csv_import.rb
@@ -93,8 +93,12 @@ module CsvImport
     end
 
     user = set_or_create_user_for_import(user_data)
+    # Remove nil values to avoid failing validations - we this allows us to
+    # update role of a bunch of users by passing in only their usernames
+    # (instead of all of their user data).
+    data_to_update = user_data.keep_if { |_, v| v.present? }
+    user.update_attributes(data_to_update)
 
-    user.update_attributes(user_data)
     # if the updated or new user is valid, save to database and add to array
     # of successful imports
     return false unless user.valid?


### PR DESCRIPTION
Resolves #1748

Allows admins to upload a user import CSV file with only the usernames
populated in order to change their roles in bulk (e.g. to ban them).
Previously this would only work if the CSV file contained all required
user attributes.

~~Blocked on #1736 and #1751.~~